### PR TITLE
Run tests on python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8] #, 3.9] #, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9] #, pypy3]
         # exclude:
         #   - os: windows-latest
         #     python-version: pypy3


### PR DESCRIPTION
Once the python 3.9 ecosystem is running (specifically, when numpy scipy, and numba are available for all platforms), the github action should run on python 3.9 as well.  It's currently failing on this branch because they don't install correctly.  We should just re-run it every few days until it passes, then merge this.