### PR TITLE
Adding align2d code that uses norm of difference instead of difference of norms

### DIFF
--- a/sxs/waveforms/alignment.py
+++ b/sxs/waveforms/alignment.py
@@ -1,7 +1,6 @@
 import numpy as np
 import scipy
 
-
 def align1d(wa, wb, t1, t2, n_brute_force=None):
     """Align waveforms by shifting in time
 
@@ -112,3 +111,147 @@ def align1d(wa, wb, t1, t2, n_brute_force=None):
     optimum = least_squares(cost, δt, bounds=(δt_lower, δt_upper))
 
     return optimum.x[0]
+
+def align2d(wa, wb, t1, t2, n_brute_force_δt=None, n_brute_force_δϕ=5, include_modes=None, no_M0_modes=False):
+    """Align waveforms by shifting in time and phase
+
+    This function determines the optimal time and phase offset to apply to `wa` by minimizing
+    the averaged (over time) L² norm (over the sphere) of the difference of the waveforms.
+
+    The integral is taken from time `t1` to `t2`.
+
+    Note that the input waveforms are assumed to be initially aligned at least well
+    enough that:
+    
+      1) the time span from `t1` to `t2` in the two waveforms will overlap at
+         least slightly after the second waveform is shifted in time; and
+      2) waveform `wb` contains all the times corresponding to `t1` to `t2` in
+         waveform `wa`.
+
+    The first of these can usually be assured by simply aligning the peaks prior to
+    calling this function:
+
+        wa.t -= wa.max_norm_time() - wb.max_norm_time()
+
+    The second assumption will be satisfied as long as `t1` is not too close to the
+    beginning of `wb` and `t2` is not too close to the end.
+
+    Parameters
+    ----------
+    wa : WaveformModes
+    wb : WaveformModes
+        Waveforms to be aligned
+    t1 : float
+    t2 : float
+        Beginning and end of integration interval
+    n_brute_force_δt : int, optional
+        Number of evenly spaced δt values between (t1-t2) and (t2-t1) to sample
+        for the initial guess.  By default, this is just the maximum number of
+        time steps in the range (t1, t2) in the input waveforms.  If this is
+        too small, an incorrect local minimum may be found.
+    n_brute_force_δϕ : int, optional
+        Number of evenly spaced δϕ values between 0 and 2π to sample
+        for the initial guess.  By default, this is 5, but if the option
+        `None` is provided, then this will be 2 * ell_max + 1. This option
+        is not the default because, even though it is formally the right
+        thing to do, it takes much longer to produce the same result
+        as just using 5, which is much faster.
+    include_modes: list, optional
+        A list containing the (ell, m) modes to be included in the L² norm.
+    no_M0_modes: bool, optional
+        Whether or not to include the m = 0 modes in the L² norm.
+
+    Notes
+    -----
+    Choosing the time interval is usually the most difficult choice to make when
+    aligning waveforms.  Assuming you want to align during inspiral, the times
+    must span sufficiently long that the waveforms' norm (equivalently, orbital
+    frequency changes) significantly from `t1` to `t2`.  This means that you
+    cannot always rely on a specific number of orbits, for example.  Also note
+    that neither number should be too close to the beginning or end of either
+    waveform, to provide some "wiggle room".
+
+    Precession generally causes no problems for this function.  In principle,
+    eccentricity, center-of-mass offsets, boosts, or other supertranslations could
+    cause problems, but this function begins with a brute-force method of finding
+    the optimal time offset that will avoid local minima in all but truly
+    outrageous situations.  In particular, as long as `t1` and `t2` are separated
+    by enough, there should never be a problem.
+
+    """
+    from scipy.interpolate import CubicSpline
+    from scipy.integrate import trapezoid
+    from scipy.optimize import least_squares
+
+    wa = wa.copy()
+    wb = wb.copy()
+
+    # Check that (t1, t2) makes sense and is actually contained in both waveforms
+    if t2<=t1:
+        raise ValueError(f"(t1,t2)=({t1}, {t2}) is out of order")
+    if wa.t[0] > t1 or wa.t[-1] < t2:
+        raise ValueError(f"(t1,t2)=({t1}, {t2}) not contained in wa.t, which spans ({wa.t[0]}, {wa.t[-1]})")
+    if wb.t[0] > t1 or wb.t[-1] < t2:
+        raise ValueError(f"(t1,t2)=({t1}, {t2}) not contained in wb.t, which spans ({wb.t[0]}, {wb.t[-1]})")
+
+    # Figure out time offsets to try
+    δt_lower = max(t1 - t2, wa.t[0] - t1)
+    δt_upper = min(t2 - t1, wa.t[-1] - t2)
+
+    # We'll start by brute forcing, sampling time offsets evenly at as many
+    # points as there are time steps in (t1,t2) in the input waveforms
+    if n_brute_force_δt is None:
+        n_brute_force_δt = max(sum((wa.t>=t1)&(wa.t<=t2)), sum((wb.t>=t1)&(wb.t<=t2)))
+    δt_brute_force = np.linspace(δt_lower, δt_upper, num=n_brute_force)
+    
+    if n_brute_force_δϕ == None:
+        n_brute_force_δϕ = 2*wa.ell_max + 1
+    δϕ_brute_force = np.linspace(0, 2*np.pi, n_phi, endpoint=False)
+    
+    δt_δϕ_brute_force = np.array(np.meshgrid(δt_brute_force, δϕ_brute_force)).T.reshape(-1,2)
+
+    # Times at which the differences will be evaluated;
+    # choose a `dt` to prevent aliasing
+    dt = max(max(np.diff(wa.t[(wa.t>=t1)&(wa.t<=t2)])), max(np.diff(wb.t[(wb.t>=t1)&(wb.t<=t2)])))
+    t_reference = np.linspace(t1, t2, int((t2 - t1)/dt), endpoint=True)
+
+    # Remove M = 0 modes, if requested
+    ell_max = min(wa.ell_max, wb.ell_max)
+    if no_M0_modes:
+        for L in range(2, ell_max + 1):
+            wa.data[:,LM(L, 0, wa.ell_min)] *= 0
+            wb.data[:,LM(L, 0, wb.ell_min)] *= 0
+            
+    # Remove certain modes, if requested
+    if include_modes != None:
+        for L in range(2, ell_max + 1):
+            for M in range(-L, L + 1):
+                if not (L, M) in include_modes: 
+                    wa.data[:,LM(L, 0, wa.ell_min)] *= 0
+                    wb.data[:,LM(L, 0, wb.ell_min)] *= 0
+                    
+    # Define the cost function
+    modes_A = CubicSpline(wa.t, wa[:,2:ell_max+1].data)
+    modes_B = CubicSpline(wb.t, wb[:,2:ell_max+1].data)(t_reference)
+    
+    normalization = trapezoid(CubicSpline(wb.t, wb[:,2:ell_max + 1].norm())(t_reference), t_reference)
+    
+    δϕ_factor = np.array([M for L in range(wa.ell_min, wa.ell_max + 1) for M in range(-L, L + 1)])
+    def cost(δt_δϕ):
+        # Take the sqrt because least_squares squares the inputs...
+        diff = trapezoid(np.sum(abs(modes_A(t_reference + δt_δϕ[0]) * np.exp(1j * δt_δϕ[1]) ** δϕ_factor -\
+                                    modes_B)**2, axis=1), t_reference)
+        return np.sqrt(diff / normalization)
+
+    # Optimize by brute force
+    cost_brute_force = [cost([δt, δϕ]) for δt, δϕ in δt_δϕ_brute_force]
+    δt_δϕ = δt_δϕ_brute_force[np.argmin(cost_brute_force)]
+
+    # Optimize explicitly
+    optimum = least_squares(cost, δt_δϕ, bounds=[(δt_lower, 0), (δt_upper, 2*np.pi)])
+
+    wa_prime = wa.copy()
+    wa_prime.t = h_NR_prime.t + optimum.x[0]
+    wa_prime.data = modes_A(wa_prime.t) * np.exp(1j * optimum.x[1]) ** δϕ_factor
+    
+    return optimum, wa_prime


### PR DESCRIPTION
This code was written with the aim of aligning NR and PN waveforms, hence its different structure than `align1d`.