### PR TITLE
Fix normalization bug in align2d script

### DIFF
--- a/sxs/waveforms/alignment.py
+++ b/sxs/waveforms/alignment.py
@@ -262,7 +262,7 @@ def align2d(wa, wb, t1, t2, n_brute_force_δt=None, n_brute_force_δϕ=5, includ
 
     normalization = trapezoid(
         CubicSpline(
-            wb.t, wb[:, wb.index(2, -2) : wb.index(ell_max + 1, -(ell_max + 1))].norm
+            wb.t, wb[:, wb.index(2, -2) : wb.index(ell_max + 1, -(ell_max + 1))].norm ** 2
         )(t_reference),
         t_reference,
     )


### PR DESCRIPTION
sxs's norm is defined as the sqrt of the L^2 norm, but in the align2d code we want the actual L^2 norm.