### PR TITLE
Fix `bar` is not a property

### DIFF
--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -293,7 +293,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
             conjugate(f){s, l, m} = (-1)**(s+m) * conjugate(f{-s, l, -m})
 
         """
-        return spherical.modes.algebra.bar(self)
+        return spherical.modes.algebra.conjugate(self, False)
 
     @property
     def re(self):
@@ -944,7 +944,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
         if self.frame.shape[0] == 1:
             raise ValueError("This waveform appears to already be in an inertial frame")
         if self.frame.shape != (self.n_times, 4):
-            raise ValueError(f"Frame shape {frame.shape} not understood; expected {(self.n_times, 4)}")
+            raise ValueError(f"Frame shape {self.frame.shape} not understood; expected {(self.n_times, 4)}")
         w = self.rotate(~self.frame)
         w._metadata["frame_type"] = "inertial"
         return w


### PR DESCRIPTION
This pull request attempts to address issue #48, where `bar` is not a function to be called. Use the original `conjugate` function define in `spherical.modes` instead.

This PR also fixes a small `frame` undefined issue.

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--87.org.readthedocs.build/en/87/

<!-- readthedocs-preview sxs end -->