### PR TITLE
Fix slicing bug in waveform_modes.

### DIFF
--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -136,7 +136,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
                 sl = key[1]
                 if sl.step is None or sl.step==1:
                     ell1, m1 = self.LM[sl.start or 0]  # in case sl.start is None
-                    ell2, m2 = self.LM[sl.stop or 0 -1] # in case sl.stop is None
+                    ell2, m2 = self.LM[(sl.stop or 0)-1] # in case sl.stop is None
                     if ell1 <= ell2 and m1 == -ell1 and m2 == ell2:
                         # The sliced object has valid ell_min and ell_max values,
                         # so we can interpret it as a WaveformModes object; we

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -136,7 +136,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
                 sl = key[1]
                 if sl.step is None or sl.step==1:
                     ell1, m1 = self.LM[sl.start or 0]  # in case sl.start is None
-                    ell2, m2 = self.LM[sl.stop-1]
+                    ell2, m2 = self.LM[sl.stop or 0 -1] # in case sl.stop is None
                     if ell1 <= ell2 and m1 == -ell1 and m2 == ell2:
                         # The sliced object has valid ell_min and ell_max values,
                         # so we can interpret it as a WaveformModes object; we


### PR DESCRIPTION
Problem was if you sliced without explicitly
giving an end.  E.g. w[:,:4] was ok but w[:,4:] was not.

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--118.org.readthedocs.build/en/118/

<!-- readthedocs-preview sxs end -->