### PR TITLE
Correct factor of 2 in 4d optimization rotation

### DIFF
--- a/sxs/waveforms/alignment.py
+++ b/sxs/waveforms/alignment.py
@@ -525,7 +525,7 @@ def align4d(
     optimum = least_squares(
         cost_wrapper,
         δt_δso3,
-        bounds=[(δt_lower, -np.pi/2, -np.pi/2, -np.pi/2), (δt_upper, np.pi/2, np.pi/2, np.pi/2)],
+        bounds=[(δt_lower, -np.pi, -np.pi, -np.pi), (δt_upper, np.pi, np.pi, np.pi)],
         max_nfev=50000,
     )
     δt = optimum.x[0]


### PR DESCRIPTION
In the original 4d optimization PR this line had factors of $\pi$ instead of $\pi/2$; I believe the former was correct since the angles are free to range from 0 to $2\pi$ (note the factor of "/ 2" in line 482)

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--126.org.readthedocs.build/en/126/

<!-- readthedocs-preview sxs end -->