### PR TITLE
Indentation error in returning metadata meant no return

### DIFF
--- a/sxs/metadata/metadata.py
+++ b/sxs/metadata/metadata.py
@@ -103,7 +103,7 @@ class Metadata(collections.OrderedDict):
             else:
                 raise ValueError(f"Could not find file named '{json_path}' or '{txt_path}'")
             
-            return _backwards_compatibility(metadata)
+        return _backwards_compatibility(metadata)
 
     load = from_file
 


### PR DESCRIPTION
Indentation error in this return statement meant there was no return if taking any branches before the last one

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--130.org.readthedocs.build/en/130/

<!-- readthedocs-preview sxs end -->