### PR TITLE
Add simulation/waveform alignment functions to reproduce catalog analysis results

### DIFF
--- a/sxs/waveforms/__init__.py
+++ b/sxs/waveforms/__init__.py
@@ -18,7 +18,7 @@ from .format_handlers import (
     grathena,
 )
 from .format_handlers.lvc import to_lvc_conventions
-from . import memory, transformations, alignment
+from . import memory, transformations, alignment, norms
 
 # Map a format string to the module that should be used to load a waveform with that format
 formats = {

--- a/sxs/waveforms/alignment.py
+++ b/sxs/waveforms/alignment.py
@@ -554,7 +554,7 @@ def align4d(
 
 def map_waveform_to_canonical_frame(wa, t_ref):
     """Map waveform to canonical frame at t_ref; this amounts to
-    mapping to the peak time to zero, aligning the angular velocity
+    mapping the peak time to zero, aligning the angular velocity
     with the z axis at t_ref, fixing the phase of (2,2) to be zero
     at t_ref, and making Re[(2,1)] > 0 at t_ref.
 
@@ -567,11 +567,10 @@ def map_waveform_to_canonical_frame(wa, t_ref):
     Returns
     -------
     wa_prime: WaveformModes
-        waveform aligned to wb.
+        wa waveform aligned to wb.
     transformation: ndarray
         Transformation to map wa to wa_prime.
     """
-    
     δt = 0
     δSpin3 = quaternionic.array([0, 0, 0, 1])
 
@@ -621,9 +620,8 @@ def align_waveforms(
     reference time or by performing an alignment optimization (1d, 2d, or 4d).
 
     alignment_method determines what alignment is performed. If 'independent alignment'
-    then each simulation's frame is fixed at t_ref (if not provided, taken to be XXX
-    before the peak of sima; if '1d', '2d', or '4d', then the corresponding
-    optimization is performed over [t1, t2].
+    then each simulation's frame is fixed at t_ref; if '1d', '2d', or '4d', then the
+    corresponding optimization is performed over [t1, t2].
 
     Parameters
     ----------
@@ -642,33 +640,33 @@ def align_waveforms(
             - phase of (2,2) is set to zer at t_ref;
             - real part of the (2,1) mode is made positive at t_ref (fixes \pi freedom);
           - "1d" performs a 1d optimization over time translations;
-          - "2d" performs a 2d optimization over time translations and rotations about the z-axis;
+          - "2d" performs a 2d optimization over time translations and rotations about the z axis;
           - "4d" performs a 4d optimization over time translations and SO(3) rotations;
     t_ref : float
         Reference time, relative to peak strain, for independent alignment.
         Default is None.
     n_brute_force_δt : int, optional
-        Number of evenly spaced δt values between (t1-t2) and (t2-t1) to sample 
-        for the initial guess.  By default, this is 1,000.  If this is too small, 
+        Number of evenly spaced δt values between (t1 - t2) and (t2 - t1) to sample 
+        for the initial guess. By default, this is 1,000. If this is too small, 
         an incorrect local minimum may be found.
     n_brute_force_δϕ : int, optional
         Number of evenly spaced angles about the angular-velocity axis to sample 
-        for the initial guess.  By default, this is `2 * (2 * ell_max + 1)`.
+        for the initial guess. By default, this is `2 * (2 * ell_max + 1)`.
     max_δt : float, optional
         Max δt to allow for when choosing the initial guess.
     omega_tol: float, optional
         Angular velocity magnitude tolerance to be used to fix rotation.
         Default is 0.1
     nprocs : int, optional
-        Number of cpus to use.  Default is maximum number.  If -1 is provided, 
+        Number of cpus to use. Default is maximum number. If -1 is provided, 
         then no multiprocessing is performed.
 
     Returns
     -------
     wa_prime : WaveformModes
-        Waveform aligned to wb.
+        wa waveform aligned to wb.
     transformation : ndarray
-        Transformation to map wa to wa_prime.
+        Transformation ([dt, *SO(3) quaternion]) to map wa to wa_prime.
     L2_norm : float
         L² norm of wa_prime and wb over [t1, t2].
     """
@@ -718,9 +716,9 @@ def align_simulations(
     reference time or by performing an alignment optimization (1d, 2d, or 4d).
 
     alignment_method determines what alignment is performed. If 'independent alignment'
-    then each simulation's frame is fixed at t_ref (if not provided, taken to be XXX
-    before the peak of sima; if '1d', '2d', or '4d', then the corresponding
-    optimization is performed over [t1, t2].
+    then each simulation's frame is fixed at t_ref (if not provided, taken to be 10%
+    of the pre-merger phase before the peak of sima; if '1d', '2d', or '4d', then the
+    corresponding optimization is performed over [t1, t2].
 
     Parameters
     ----------
@@ -764,10 +762,10 @@ def align_simulations(
 
     Returns
     -------
-    wa_prime : Simulation
-        Simulation sima.h aligned to Simulation simb.h.
-    transformation : BMSTransformation
-        BMS transformation to map sima.h to wa_prime.
+    wa_prime : WaveformModes
+        Waveform sima.h aligned to Simulation simb.h.
+    transformation : ndarray
+        Transformation ([dt, *SO(3) quaternion]) to map sima.h to wa_prime.
     L2_norm : float
         L² norm of wa_prime and wb over [t1, t2].
     """

--- a/sxs/waveforms/memory.py
+++ b/sxs/waveforms/memory.py
@@ -13,37 +13,7 @@ h_with_memory = sxs.waveforms.memory.add_memory(h, integration_start_time=1000.0
 """
 
 import numpy as np
-import spherical
-from . import WaveformModes
-
-
-class _ModesTimeSeries(WaveformModes):
-
-    @property
-    def s(self):
-        return self.spin_weight
-
-    @property
-    def u(self):
-        return self.time
-
-    from spherical.modes.algebra import (
-        conjugate, bar, _real_func, real, _imag_func, imag, norm,
-        add, subtract, multiply, divide
-    )
-
-    conj = conjugate
-
-    from spherical.modes.utilities import (
-        truncate_ell, _check_broadcasting
-    )
-
-    from spherical.modes.ufuncs import __array_ufunc__
-
-
-def MTS(*args, **kwargs):
-    kwargs.setdefault('multiplication_truncator', max)
-    return _ModesTimeSeries(*args, **kwargs)
+from . import waveform_mts
 
 
 def 𝔇(h_mts):
@@ -107,8 +77,8 @@ def 𝔇inverseLaplacianinverse(h_mts):
 
 
 def mass_aspect(Psi2, h):
-    h = MTS(h)
-    Psi2 = MTS(Psi2)
+    h = waveform_mts.MTS(h)
+    Psi2 = MTSwaveform_mts.MTS(Psi2)
     return - (Psi2 + 0.25 * h.dot * h.bar).re
 
 
@@ -131,8 +101,8 @@ def J_m(h, Psi2):
         Bondi mass aspect contribution to the strain
 
     """
-    h = MTS(h)
-    Psi2 = MTS(Psi2)
+    h = waveform_mts.MTS(h)
+    Psi2 = waveform_mts.MTS(Psi2)
     m = mass_aspect(Psi2, h)
     J_m = 0.5 * 𝔇inverse(m).ethbar.ethbar
 
@@ -160,7 +130,7 @@ def J_E(h, integration_start_time=None):
 
     """
 
-    hdot = MTS(h).dot
+    hdot = waveform_mts.MTS(h).dot
 
     J_ℰ = 0.5 * 𝔇inverse(0.25 * (hdot * hdot.bar).int).ethbar.ethbar
 
@@ -191,8 +161,8 @@ def J_Nhat(h, Psi2):
 
     """
 
-    h = MTS(h)
-    Psi2 = MTS(Psi2)
+    h = waveform_mts.MTS(h)
+    Psi2 = waveform_mts.MTS(Psi2)
 
     # # Note that the contributions from the last two terms drop out as soon as we
     # # take the imaginary part below.
@@ -228,7 +198,7 @@ def J_J(h):
 
     """
 
-    h = MTS(h)
+    h = waveform_mts.MTS(h)
     hdot = h.dot
     J_𝒥 = 0.5j * 𝔇inverseLaplacianinverse(
         0.125 * (3 * h * hdot.bar.ethbar - 3 * hdot * h.bar.ethbar + hdot.bar * h.ethbar - h.bar * hdot.ethbar).eth.im
@@ -263,11 +233,11 @@ def add_memory(h, integration_start_time=None, psi4=None):
 
     """
     h_memory_correction = J_E(h, integration_start_time=integration_start_time)
-    h_with_memory = WaveformModes(MTS(h) + h_memory_correction)
+    h_with_memory = WaveformModes(waveform_mts.MTS(h) + h_memory_correction)
     h_with_memory.register_modification(add_memory, integration_start_time=integration_start_time)
     if psi4 is None:
         return h_with_memory
     else:
-        psi4_with_memory = WaveformModes(MTS(psi4) - MTS(h_memory_correction).ddot)
+        psi4_with_memory = WaveformModes(waveform_mts.MTS(psi4) - waveform_mts.MTS(h_memory_correction).ddot)
         psi4_with_memory.register_modification(add_memory, integration_start_time=integration_start_time)
         return (h_with_memory, psi4_with_memory)

--- a/sxs/waveforms/memory.py
+++ b/sxs/waveforms/memory.py
@@ -78,7 +78,7 @@ def 𝔇inverseLaplacianinverse(h_mts):
 
 def mass_aspect(Psi2, h):
     h = waveform_mts.MTS(h)
-    Psi2 = MTSwaveform_mts.MTS(Psi2)
+    Psi2 = waveform_mts.MTS(Psi2)
     return - (Psi2 + 0.25 * h.dot * h.bar).re
 
 

--- a/sxs/waveforms/norms.py
+++ b/sxs/waveforms/norms.py
@@ -1,0 +1,226 @@
+import numpy as np
+from quaternion.calculus import indefinite_integral as integrate
+
+from .waveform_mts import MTS
+
+def check_time_constraint(wa, wb, t1, t2):
+    """Check that the times t1 and t2 are contained in wa.t and wb.t.
+
+    Parameters
+    ----------
+    wa : WaveformModes
+    wb : WaveformModes
+    t1 : float
+    t2 : float
+    """
+    time_intersection = (max(wa.t[0], wb.t[0]), min(wa.t[-1], wb.t[-1]))
+    if t1 < time_intersection[0]:
+        raise ValueError(
+            f"{t1} is not contained in intersection of waveform time arrays: {time_intersection}."
+        )
+    if t2 > time_intersection[1]:
+        raise ValueError(
+            f"{t2} is not contained in intersection of waveform time arrays: {time_intersection}."
+        )
+
+def create_unified_waveforms(wa, wb, t1, t2, padding_time_factor=0.2):
+    """Make two sxs.WaveformModes objects share a common time array
+    that contains the times t1 and t2.
+
+    Parameters
+    ----------
+    wa : WaveformModes
+    wb : WaveformModes
+    t1 : float
+    t2 : float
+    padding_time_factor : float, optional
+        Extra time of size (t2 - t1)*padding_time_factor to include in the waveforms.
+        Default is 0.2.
+
+    Returns
+    -------
+    wa_interp : WaveformModes
+    wa_interp : WaveformModes
+    """
+    check_time_constraint(wa, wb, t1, t2)
+
+    padding_time = (t2 - t1) * padding_time_factor
+    t1_padded = max(max(wa.t[0], wb.t[0]), t1 - padding_time)
+    t2_padded = min(min(wa.t[-1], wb.t[-1]), t2 + padding_time)
+
+    idx1 = np.argmin(abs(wa.t - t1_padded))
+    idx2 = np.argmin(abs(wa.t - t2_padded)) + 1
+
+    wa_interp = wa.interpolate(wa.t[idx1:idx2])
+    wb_interp = wb.interpolate(wa_interp.t)
+
+    return wa_interp, wb_interp
+
+def compute_L2_norm(
+    wa, wb, t1=None, t2=None, modes=None, modes_for_norm=None, normalize=True
+):
+    """Compute the L2 norm between two waveforms over the
+    time window (t1, t2) using the modes specified by `modes`.
+
+    Parameters
+    ----------
+    wa : WaveformModes
+    wb : WaveformModes
+        Interpolated to wa over (t1, t2).
+    t1 : float
+        Beginning of L2 norm integral.
+    t2 : float
+        End of L2 norm integral.
+    modes : list, optional
+        Modes (\ell, m) to include in numerator of L2 norm calculation.
+        Default is all modes.
+    modes_for_norm : list, optional
+        Modes (\ell, m) to include in denominator of L2 norm calculation.
+        Default is all modes.
+    normalize : bool, optional
+        Whether or not to divide by ||wa||² in the sqrt. If False, returns
+        the unnormalized L2 norm and what would have been the normalization.
+        Default is True.
+
+    Returns
+    -------
+    L2_norm: float
+        L2 norm between to the waveforms
+        This is sqrt( ||wa - wb||² / ||wa||² )
+    """
+    wa = wa.copy()
+    wb = wb.copy()
+
+    if t1 is None:
+        t1 = max(wa.t[0], wb.t[0])
+        
+    if t2 is None:
+        t2 = min(wa.t[-1], wb.t[-1])
+
+    wa, wb = create_unified_waveforms(
+        wa, wb, t1, t2, padding_time_factor=0
+    )
+
+    data_diff = wa.data - wb.data
+
+    data_for_norm = wa.data
+    
+    # Eliminate unwanted modes
+    if modes is not None or modes_for_norm is not None:
+        for L in range(wa.ell_min, wa.ell_max + 1):
+            for M in range(-L, L + 1):
+                if modes is not None:
+                    if not (L, M) in modes:
+                        data_diff[:, wa.index(L, M)] *= 0
+                if modes_for_norm is not None:
+                    if not (L, M) in modes_for_norm:
+                        data_for_norm[:, wa.index(L, M)] *= 0
+                        
+    if normalize:
+        L2_norm = np.sqrt(
+            integrate(np.linalg.norm(data_diff, axis=wa.modes_axis)**2, wa.t)[-1]
+            / integrate(np.linalg.norm(data_for_norm, axis=wa.modes_axis)**2, wa.t)[-1]
+        )
+
+        return L2_norm
+    else:
+        L2_norm_unnormalized = np.sqrt(integrate(np.linalg.norm(data_diff, axis=wa.modes_axis)**2, wa.t)[-1])
+        norm = np.sqrt(integrate(np.linalg.norm(data_for_norm, axis=wa.modes_axis)**2, wa.t)[-1])
+
+        return L2_unnormalized, norm
+
+def overlap(wa_mts, wb_mts, t1, t2, modes=None, ASD=None):
+    """
+    Compute the overlap between two waveforms over the
+    time window (t1, t2) using the modes specified by `modes`.
+
+    If an ASD curve is provided, then compute the noise-weighted overlap.
+
+    Parameters
+    ----------
+    wa_mts : ModesTimeSeries
+    wb_mts : ModesTimeSeries
+    t1 : float
+        Beginning of overlap integral.
+    t2 : float
+        End of overlap integral.
+    modes : list, optional
+        Default is all modes.
+    ASD : ndarray, optional
+        Array containing ASD information for a detector.
+
+    Returns
+    -------
+    overlap : float
+        Overlap between the two waveforms.
+    """
+    overlap = integrate(
+        np.sqrt(4 * np.pi)
+        * wa_mts.multiply(wb_mts.bar, truncator=lambda tup: 0).ndarray[:, 0]
+        / ASD ** 2,
+        wa_mts.t,
+    )[-1]
+
+    return overlap
+
+
+def compute_mismatch(wa, wb, t1=None, t2=None, modes=None, ASD=None):
+    """
+    Compute the mismatch between two waveforms over the
+    time window (t1, t2) using the modes specified by `modes`.
+
+    Parameters
+    ----------
+    wa : WaveformModes
+    wb : WaveformModes
+    t1 : float
+        Beginning of L2 norm integral.
+    t2 : float
+        End of L2 norm integral.
+    modes : list, optional
+        Default is all modes.
+    ASD : ndarray, optional
+        Array containing requency and ASD information for a detector.
+        This should be of shape (..., 2).
+
+    Returns
+    -------
+    mismatch : float
+        Mismatch between the two waveforms.
+    """
+    wa = wa.copy()
+    wb = wb.copy()
+
+    if t1 is None:
+        t1 = max(wa.t[0], wb.t[0])
+        
+    if t2 is None:
+        t2 = min(wa.t[-1], wb.t[-1])
+
+    wa, wb = create_unified_waveforms(
+        wa, wb, t1, t2, padding_time_factor=0
+    )
+        
+    # Eliminate unwanted modes
+    if modes is not None:
+        ell_min = min(wa.ell_min, wb.ell_min)
+        ell_max = max(wa.ell_max, wb.ell_max)
+        for L in range(ell_min, ell_max + 1):
+            for M in range(-L, L + 1):
+                if not (L, M) in modes:
+                    wa.data[:, wa.index(L, M)] *= 0
+                    wb.data[:, wb.index(L, M)] *= 0
+                    
+    wa_mts = MTS(wa)
+    wb_mts = MTS(wb)
+
+    if ASD is None:
+        ASD = np.ones_like(wa_mts.t)
+    
+    wa_wb_overlap = overlap(wa_mts, wb_mts, t1, t2, modes, ASD).real
+    wa_norm = overlap(wa_mts, wa_mts, t1, t2, modes, ASD).real
+    wb_norm = overlap(wb_mts, wb_mts, t1, t2, modes, ASD).real
+
+    mismatch = 1 - wa_wb_overlap / np.sqrt(wa_norm * wb_norm)
+
+    return mismatch

--- a/sxs/waveforms/waveform_mts.py
+++ b/sxs/waveforms/waveform_mts.py
@@ -1,0 +1,30 @@
+import spherical
+from . import WaveformModes
+
+class _ModesTimeSeries(WaveformModes):
+
+    @property
+    def s(self):
+        return self.spin_weight
+
+    @property
+    def u(self):
+        return self.time
+
+    from spherical.modes.algebra import (
+        conjugate, bar, _real_func, real, _imag_func, imag, norm,
+        add, subtract, multiply, divide
+    )
+
+    conj = conjugate
+
+    from spherical.modes.utilities import (
+        truncate_ell, _check_broadcasting
+    )
+
+    from spherical.modes.ufuncs import __array_ufunc__
+
+
+def MTS(*args, **kwargs):
+    kwargs.setdefault('multiplication_truncator', max)
+    return _ModesTimeSeries(*args, **kwargs)

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,0 +1,96 @@
+import numpy as np
+import quaternionic
+import pytest
+import sxs
+from .conftest import physicalish_waveform
+
+def test_independent_alignment():
+    h1 = physicalish_waveform()
+    
+    δt = 10 * np.random.rand()
+    δSpin3 = quaternionic.array([np.random.rand(), np.random.rand(), np.random.rand(), np.random.rand()]).normalized
+    
+    h2 = h1.copy()
+    h2.t = h2.t - δt
+    h2 = h2.rotate(δSpin3)
+
+    t1 = -80
+    t2 = 80
+    h1_prime, transformation, norm = sxs.waveforms.alignment.align_waveforms(
+        h1,
+        h2,
+        t1,
+        t2,
+        alignment_method="independent alignment",
+        t_ref=-20
+    )
+    
+    assert np.allclose(norm, 0., atol=1e-6)
+    assert np.allclose([δt, *δSpin3.ndarray], transformation, atol=1e-6)
+    
+def test_align1d():
+    h1 = physicalish_waveform()
+    
+    δt = 10 * np.random.rand()
+    
+    h2 = h1.copy()
+    h2.t = h2.t - δt
+    
+    t1 = -80
+    t2 = 80
+    h1_prime, transformation, norm = sxs.waveforms.alignment.align_waveforms(
+        h1,
+        h2,
+        t1,
+        t2,
+        alignment_method="1d"
+    )
+    
+    assert np.allclose(norm, 0., atol=1e-6)
+    assert np.allclose(δt, transformation[0], atol=1e-6)
+    
+def test_align2d():
+    h1 = physicalish_waveform()
+    
+    δt = 10 * np.random.rand()
+    δSpin3 = quaternionic.array([np.random.rand(), 0., 0., np.random.rand()]).normalized
+    
+    h2 = h1.copy()
+    h2.t = h2.t - δt
+    h2 = h2.rotate(δSpin3)
+
+    t1 = -80
+    t2 = 80
+    h1_prime, transformation, norm = sxs.waveforms.alignment.align_waveforms(
+        h1,
+        h2,
+        t1,
+        t2,
+        alignment_method="2d"
+    )
+    
+    assert np.allclose(norm, 0., atol=1e-6)
+    assert np.allclose([δt, *δSpin3.ndarray], transformation, atol=1e-6)
+    
+def test_align4d():
+    h1 = physicalish_waveform()
+    
+    δt = 10 * np.random.rand()
+    δSpin3 = quaternionic.array([np.random.rand(), np.random.rand(), np.random.rand(), np.random.rand()]).normalized
+    
+    h2 = h1.copy()
+    h2.t = h2.t - δt
+    h2 = h2.rotate(δSpin3)
+
+    t1 = -80
+    t2 = 80
+    h1_prime, transformation, norm = sxs.waveforms.alignment.align_waveforms(
+        h1,
+        h2,
+        t1,
+        t2,
+        alignment_method="4d"
+    )
+    
+    assert np.allclose(norm, 0., atol=1e-6)
+    assert np.allclose([δt, *δSpin3.ndarray], transformation, atol=1e-6)


### PR DESCRIPTION
@moble this is suppose to serve as the base for updating `sxs` to include the code necessary to reproduce the analysis that we're presenting in the catalog paper. I figured it'd be good for us to discuss things and merge this (or maybe some modified/edited version of it) first before I dig too deep into adding the more specific error functions, e.g., mismatches with respect to ASD curves or individual mode errors. Let me know your thoughts and if you'd like me to change anything. Otherwise we can also discuss this during the vacuum call.