### PR TITLE
SimulationBase.load_metadata should add computed md fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Astronomy"
 ]
 dependencies = [
-  "sxscatalog >=3.0.13",
+  "sxscatalog >=3.0.14",
   "numpy >=1.25",
   "scipy >=1.13",
   "numba >=0.55; implementation_name == 'cpython'",

--- a/sxs/simulations/simulation.py
+++ b/sxs/simulations/simulation.py
@@ -520,7 +520,9 @@ class SimulationBase:
         metadata_location = self.files.get(metadata_path)["link"]
         sxs_id_path = Path(self.sxs_id)
         metadata_truepath = Path(sxs_path_to_system_path(sxs_id_path / metadata_path))
-        return Metadata(load(metadata_location, truepath=metadata_truepath))
+        return Metadata(
+            load(metadata_location, truepath=metadata_truepath)
+        ).add_standard_parameters()
 
     def load_horizons(self):
         from .. import load


### PR DESCRIPTION
less-than-maximal Lev and older version simulations have `metadata=None` passed to
`Simulation_vN.__init__()`, which makes `__init__` call `load_metadata()`. But this
results in different behavior for the metadata loaded for less-than-maximal Lev
and older versions, since their metadata object is not constructed the same way
as in `load("simulations")[simulation_id]`.

Try to make it more uniform by using the `sxscatalog` functions
`_backwards_compatibility()` and `.add_standard_parameters()`.