### PR TITLE
RPDMB: load t<0 by default, but drop when loading via Simulation_v{2,3}

### DIFF
--- a/sxs/simulations/simulation.py
+++ b/sxs/simulations/simulation.py
@@ -782,6 +782,7 @@ class SimulationBase:
         strain = self.load_waveform(
             *self.strain_path,
             transform_to_inertial=False,
+            drop_times_before=kwargs.pop("drop_times_before", 0)
         )
         return to_lvc_conventions(strain, self.horizons, **kwargs)
 
@@ -933,7 +934,7 @@ class Simulation_v2(SimulationBase):
             download_file(json_location, json_truepath)
         return load(
             h5_location, truepath=h5_truepath, group=group, metadata=self.metadata,
-            transform_to_inertial=transform_to_inertial
+            transform_to_inertial=transform_to_inertial, drop_times_before=0,
         )
 
 

--- a/sxs/waveforms/format_handlers/rotating_paired_diff_multishuffle_bzip2.py
+++ b/sxs/waveforms/format_handlers/rotating_paired_diff_multishuffle_bzip2.py
@@ -387,9 +387,8 @@ def load(
         a string is given, the corresponding time will be used.  The
         "begin" option represents the earliest time in the data, so no
         data will be dropped; "reference" is the `reference_time`
-        reported in the metadata.  If `None`, the default, t=0 will be
-        used if present in the data, and the first time step
-        otherwise.
+        reported in the metadata.  If no argument is given, all times
+        will be used ("begin").
     metadata : Metadata, optional
         If given, this metadata will be used instead of attempting to
         load the metadata from an accompanying file.
@@ -582,7 +581,7 @@ def load(
         except ValueError as e:
             invalid(f"\n{e},\nbut one is expected for this data format.")
 
-    dtb = kwargs.pop("drop_times_before", 0)
+    dtb = kwargs.pop("drop_times_before", "begin")
     if dtb=="begin":
         i0 = 0
     elif dtb==0:


### PR DESCRIPTION
Closes #116

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--164.org.readthedocs.build/en/164/

<!-- readthedocs-preview sxs end -->