### PR TITLE
Modified align2d()

### DIFF
--- a/sxs/waveforms/alignment.py
+++ b/sxs/waveforms/alignment.py
@@ -197,10 +197,10 @@ def align2d(
     nprocs: int, optional
         Number of cpus to use. Default is maximum number.
         If -1 is provided, then no multiprocessing is performed.
-    max_nfev: None or int, optional
+    max_nfev: int, optional
         Parameter for scipy.optimize.least_squares.
         Controls the maximum number of function evaluations used. 
-        If None (default), the value is 100 * number of parameters
+        By default, max_nfev = 50000
     ftol: float, optional
         Parameter for scipy.optimize.least_squares.
         Tolerance for termination by the change of the cost function F. 
@@ -427,10 +427,10 @@ def align4d(
     nprocs: int, optional
         Number of cpus to use.  Default is maximum number.  If -1 is provided,
         then no multiprocessing is performed.
-    max_nfev: None or int, optional
+    max_nfev: int, optional
         Parameter for scipy.optimize.least_squares.
         Controls the maximum number of function evaluations used. 
-        If None (default), the value is 100 * number of parameters
+        By default, max_nfev = 50000
     ftol: float, optional
         Parameter for scipy.optimize.least_squares.
         Tolerance for termination by the change of the cost function F. 
@@ -536,7 +536,7 @@ def align4d(
 
     # Optimize by brute force with multiprocessing
     cost_wrapper = partial(_cost4d, args=[modes_A, modes_B, t_reference, normalization])
-    
+
     if nprocs != -1:
         if nprocs is None:
             nprocs = mp.cpu_count()


### PR DESCRIPTION
1. Added an optional parameter `ftol` — tolerance for termination by the change of the cost function F. The optimization process is stopped when dF < ftol * F.
2. Added the trivial shift of `(δt, δϕ) = (0,0)`, and the trigger for that is` cost_wrapper([0.0, 0.0]) == 0`

-------  Optional to read ------
Initially, I thought `scipy.optimize.least_squares` would take several steps until the tolerance is met, then return the last step. And that is why we are missing `(0,0)`. To improve performance, I compared the cost of the last step and the previous one, choosing whichever was lower. Later, I realized this was unnecessary—`scipy.optimize.least_squares` interpolates between steps, so the final result may lie between them. As a result, comparing the last two steps wouldn't improve. Thus, just by simply check ` cost_wrapper([0.0, 0.0]) == 0` at the beginning is a simple and robust way

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--166.org.readthedocs.build/en/166/

<!-- readthedocs-preview sxs end -->