### PR TITLE
Changing frame to take Q.array rather than np.array

### DIFF
--- a/sxs/julia/__init__.py
+++ b/sxs/julia/__init__.py
@@ -75,7 +75,7 @@ def PNWaveform(
         data_type = "h"
     elif modes_function is Ψ_M_bang:
         spin_weight = 0
-        data_type = "unknown"
+        data_type = "psim"
     else:
         raise ValueError("spin_weight and data_type can not be inferred for unknown modes_function. modes_function should be h_bang or Ψ_M_bang.")
 

--- a/sxs/julia/__init__.py
+++ b/sxs/julia/__init__.py
@@ -88,7 +88,7 @@ def PNWaveform(
             raise ValueError("ell_min can not be inferred for unknown modes_function.")
 
     if inertial:
-        frame = np.array([quaternionic.one])
+        frame = quaternionic.array([quaternionic.one])
         frame_type = "inertial"
         w_pn = PostNewtonian.inertial_waveform(
             inspiral, modes_function=modes_function, ell_min=ell_min,

--- a/tests/test_julia.py
+++ b/tests/test_julia.py
@@ -45,7 +45,7 @@ def test_PNWaveform():
 
     assert np.allclose(w1.t[:-10], w2.t[:-10])
     assert np.allclose(w1.data[:-10, :], w2.data[:-10, :], rtol=1e-3, atol=1e-5)
-    assert np.allclose(w1.frame, w2.frame)
+    assert np.allclose(np.asarray(w1.frame), np.asarray(w2.frame))
     assert np.allclose(w1.M1[:-10], w2.M1[:-10])
     assert np.allclose(w1.M2[:-10], w2.M2[:-10])
     assert np.allclose(w1.chi1[:-10, :], w2.chi1[:-10, :], rtol=1e-3)


### PR DESCRIPTION
Hi @moble and @duetosymmetry. I think this is a bug. The frame property should be of type `Q.array` rather than `np.array`. I found this while trying to load `sxs.WaveformModes` object to `scri.WaveformModes` object using `from_sxs` method in scri. Please let me know if this is an appropriate change.

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--190.org.readthedocs.build/en/190/

<!-- readthedocs-preview sxs end -->