### PR TITLE
load RIT and MAYA simulations dataframe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Astronomy"
 ]
 dependencies = [
-  "sxscatalog >=3.0.14",
+  "sxscatalog >=3.0.23",
   "numpy >=2.0, <3.0",
   "scipy >=1.13",
   "numba >=0.55; implementation_name == 'cpython'",

--- a/sxs/handlers.py
+++ b/sxs/handlers.py
@@ -276,7 +276,7 @@ def load(location, download=None, cache=None, progress=None, truepath=None, **kw
         elif location == "catalog":
             return Catalog.load(download=download)
 
-        elif location in ["simulations", "dataframe"]:
+        elif location in ["simulations", "dataframe", "RITsimulations", "RITdataframe", "MAYAsimulations", "MAYAdataframe"]:
             return sxscatalog.load(location, download=download, **kwargs)
 
         elif _safe_resolve_exists(h5_path):


### PR DESCRIPTION
Hi @moble and @duetosymmetry. This small changes enables sxs package to load the RIT and MAYA simulations dataframe. Can you please review this?

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--193.org.readthedocs.build/en/193/

<!-- readthedocs-preview sxs end -->