### PR TITLE
Add RITSimulation function and RITSimulation_v4 class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Astronomy"
 ]
 dependencies = [
-  "sxscatalog >=3.0.23",
+  "sxscatalog >=3.0.28",
   "numpy >=2.0, <3.0",
   "scipy >=1.13",
   "numba >=0.55; implementation_name == 'cpython'",

--- a/sxs/__init__.py
+++ b/sxs/__init__.py
@@ -30,7 +30,7 @@ from .waveforms import rotating_paired_xor_multishuffle_bzip2 as rpxmb
 from .waveforms import rotating_paired_diff_multishuffle_bzip2 as rpdmb
 from .waveforms import spectre_cce_v1
 from . import catalog, metadata, horizons, waveforms, zenodo
-from .simulations import Simulation, Simulations, write_local_simulations, local_simulations
+from .simulations import Simulation, RITSimulation, Simulations, write_local_simulations, local_simulations
 from .handlers import load, load_via_sxs_id, loadcontext, load_lvc
 
 # The speed of light is, of course, defined to be exactly

--- a/sxs/__init__.py
+++ b/sxs/__init__.py
@@ -30,7 +30,10 @@ from .waveforms import rotating_paired_xor_multishuffle_bzip2 as rpxmb
 from .waveforms import rotating_paired_diff_multishuffle_bzip2 as rpdmb
 from .waveforms import spectre_cce_v1
 from . import catalog, metadata, horizons, waveforms, zenodo
-from .simulations import Simulation, RITSimulation, Simulations, write_local_simulations, local_simulations
+from .simulations import (
+    Simulation, RITSimulation, Simulations,
+    write_local_simulations, local_simulations,
+    )
 from .handlers import load, load_via_sxs_id, loadcontext, load_lvc
 
 # The speed of light is, of course, defined to be exactly

--- a/sxs/handlers.py
+++ b/sxs/handlers.py
@@ -234,6 +234,10 @@ def load(location, download=None, cache=None, progress=None, truepath=None, **kw
          the data.  Note that `download` must be explicitly set in
          this case, or a ValueError will be raised.
 
+      8) Given an RIT simulation specification — like "RIT:BBH:1234" or
+         "RIT:eBBH:1234" — the simulation is loaded as an
+         `sxs.RITSimulation` object.
+
     If the file is downloaded, it will be stored in the cache
     according to the `location`, unless `truepath` is set as noted
     above, in which case it is stored there.  Note that downloading is
@@ -243,7 +247,7 @@ def load(location, download=None, cache=None, progress=None, truepath=None, **kw
     """
     import pathlib
     import urllib.request
-    from . import Simulations, Simulation, read_config, sxs_directory, Catalog
+    from . import Simulations, Simulation, RITSimulation, read_config, sxs_directory, Catalog
     from .utilities import url, download_file, sxs_path_to_system_path, sxs_id_version_lev_exact_re, lev_path_re, sxs_identifier_re
 
     # Note: `download` and/or `cache` may still be `None` after this
@@ -296,6 +300,9 @@ def load(location, download=None, cache=None, progress=None, truepath=None, **kw
 
         elif sxs_id_version_lev_exact_re.match(location):
             return Simulation(location, download=download, cache=cache, progress=progress, **kwargs)
+
+        elif location.startswith("RIT:"):
+            return RITSimulation(location, download=download, cache=cache, progress=progress, **kwargs)
 
         else:
             # Try to find an appropriate SXS file in the simulations

--- a/sxs/handlers.py
+++ b/sxs/handlers.py
@@ -247,7 +247,10 @@ def load(location, download=None, cache=None, progress=None, truepath=None, **kw
     """
     import pathlib
     import urllib.request
-    from . import Simulations, Simulation, RITSimulation, read_config, sxs_directory, Catalog
+    from . import (
+        Simulations, Simulation, RITSimulation,
+        read_config, sxs_directory, Catalog
+    )
     from .utilities import url, download_file, sxs_path_to_system_path, sxs_id_version_lev_exact_re, lev_path_re, sxs_identifier_re
 
     # Note: `download` and/or `cache` may still be `None` after this

--- a/sxs/simulations/__init__.py
+++ b/sxs/simulations/__init__.py
@@ -2,3 +2,4 @@ from .simulation import Simulation
 from .simulations import Simulations
 from .local import write_local_simulations, local_simulations
 from . import analyze
+from .rit_simulation import RITSimulation

--- a/sxs/simulations/rit_simulation.py
+++ b/sxs/simulations/rit_simulation.py
@@ -1,8 +1,8 @@
 import urllib
-from pathlib import PurePosixPath
+from pathlib import PurePosixPath, Path
 from .simulation import SimulationBase
 from .. import Metadata
-from ..utilities import download_file, sxs_directory
+from ..utilities import download_file, sxs_directory, sxs_path_to_system_path
 
 
 def _not_defined_property(name):
@@ -70,7 +70,7 @@ def RITSimulation(location, *args, **kwargs):
         location,
         *args, **kwargs
     )
-    sim.__file__ = str(sxs_directory("cache") / location)
+    sim.__file__ = str(sxs_directory("cache") / sxs_path_to_system_path(location))
     return sim
 
 
@@ -106,37 +106,40 @@ class RITSimulation_v4(SimulationBase):
         construction += f"e={e:.3g} simulation" if type(e) is float else f"{e=} simulation"
         return construction
 
-    def load_waveform(self, location):
-
-        from ..waveforms import lvcnr
-
-        strain_url = self.metadata.extrap_strain_url
-        strain_path = urllib.parse.urlparse(strain_url).path
-        filename = PurePosixPath(strain_path).name
-
-        path = sxs_directory("cache") / location / filename
-
-        if not path.exists():
-            download_file(strain_url, path)
-
-        w = lvcnr.load(path)
-        w.metadata = self.metadata
-
-        return w
-
     distances = _not_implemented_function("distances")
     closest_simulation = _not_implemented_function("closest_simulation")
+    load_waveform = _not_implemented_function("load_waveform")
     load_horizons = _not_implemented_function("load_horizons")
 
     @property
     def strain(self):
         if not hasattr(self, "_strain"):
-            self._strain = self.load_waveform(self.location)
+            from ..waveforms import lvcnr
+
+            strain_url = self.metadata.extrap_strain_url
+            strain_path = urllib.parse.urlparse(strain_url).path
+            filename = PurePosixPath(strain_path).name
+            location = Path(self.location)
+
+            path = sxs_directory("cache") / location / filename
+
+            if not path.exists():
+                download_file(strain_url, path)
+
+            w = lvcnr.load(path)
+            w.metadata = self.metadata
+
+            self._strain = w
         return self._strain
 
     Strain = strain
     h = strain
     H = strain
+
+    @property
+    def psi4(self):
+        raise NotImplementedError(f"psi4 is currently not implemented for RITSimulation_v4.")
+    Psi4 = psi4
 
     versions = _not_defined_property("versions")
     lev = _not_defined_property("lev")

--- a/sxs/simulations/rit_simulation.py
+++ b/sxs/simulations/rit_simulation.py
@@ -1,4 +1,5 @@
-from pathlib import Path
+import urllib
+from pathlib import PurePosixPath
 from .simulation import SimulationBase
 from .. import Metadata
 from ..utilities import download_file, sxs_directory
@@ -69,6 +70,7 @@ def RITSimulation(location, *args, **kwargs):
         version=version,
         files=files,
         location=location,
+        *args, **kwargs
     )
     sim.__file__ = str(sxs_directory("cache") / location)
     return sim
@@ -111,7 +113,8 @@ class RITSimulation_v4(SimulationBase):
         from ..waveforms import lvcnr
 
         strain_url = self.metadata.extrap_strain_url
-        filename = Path(strain_url).name
+        strain_path = urllib.parse.urlparse(strain_url).path
+        filename = PurePosixPath(strain_path).name
 
         path = sxs_directory("cache") / location / filename
 

--- a/sxs/simulations/rit_simulation.py
+++ b/sxs/simulations/rit_simulation.py
@@ -8,8 +8,7 @@ from ..utilities import download_file, sxs_directory
 def _not_defined_property(name):
     @property
     def prop(self):
-        raise AttributeError(f"'{name}' is not supported for version {self.version} of the catalog.")
-
+        raise AttributeError(f"'{name}' is not available for RIT simulations (version {self.version}).")
     return prop
 
 
@@ -38,8 +37,7 @@ def RITSimulation(location, *args, **kwargs):
     Returns
     -------
     simulation : SimulationBase
-        A `RITSimulation_v4` object, depending on the version of the simulation
-        data.
+        An `RITSimulation_v4` object.
 
     Note that all remaining arguments (including keyword arguments)
     are passed on to the `SimulationBase` constructors.
@@ -65,11 +63,11 @@ def RITSimulation(location, *args, **kwargs):
     version = "v4.0"
 
     sim = RITSimulation_v4(
-        metadata=metadata,
-        series=series,
-        version=version,
-        files=files,
-        location=location,
+        metadata,
+        series,
+        version,
+        files,
+        location,
         *args, **kwargs
     )
     sim.__file__ = str(sxs_directory("cache") / location)
@@ -86,10 +84,10 @@ class RITSimulation_v4(SimulationBase):
     """
 
     def __init__(self, metadata, series, version, files, location, *args, **kwargs):
-    # Note that we want just a subset of the constructor of SimulationBase here.
-    # Therefore, we don't use the super of SimulationsBase.
-    # This keeps the constructor clean and avoids setting positional arguments -
-    # sxs_id_stem, sxs_id, url, lev_numbers and lev_number to None.
+        # Note that we want just a subset of the constructor of SimulationBase here.
+        # Therefore, we don't use the super of SimulationsBase.
+        # This keeps the constructor clean and avoids setting positional arguments -
+        # sxs_id_stem, sxs_id, url, lev_numbers and lev_number to None.
         self.metadata = metadata
         self.series = series
         self.version = version
@@ -145,3 +143,4 @@ class RITSimulation_v4(SimulationBase):
     Lev = _not_defined_property("Lev")
     metadata_path = _not_defined_property("metadata_path")
     horizons = _not_defined_property("horizons")
+    Horizons = horizons

--- a/sxs/simulations/rit_simulation.py
+++ b/sxs/simulations/rit_simulation.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+from .simulation import SimulationBase
+from .. import Metadata
+from ..utilities import download_file, sxs_directory
+
+
+def _not_defined_property(name):
+    @property
+    def prop(self):
+        raise AttributeError(f"'{name}' is not supported for version {self.version} of the catalog.")
+
+    return prop
+
+
+def _not_implemented_function(name):
+    def function(self, *args, **kwargs):
+        raise NotImplementedError(f"'{name}' cannot be implemented for version {self.version} of the data.")
+
+    return function
+
+
+def RITSimulation(location, *args, **kwargs):
+    """Construct a RITSimulation object from a location string.
+
+    The location string should be an RIT ID, as in "RIT:BBH:xxxx" or
+    "RIT:eBBH:xxxx". It must exist, or no files will be found to load the data
+    from.
+
+    The returned object will be a `RITSimulation_v4` object.
+
+    Parameters
+    ----------
+    location : str
+        The location string for the simulation.  This must include the
+        RIT ID as described above.
+
+    Returns
+    -------
+    simulation : SimulationBase
+        A `RITSimulation_v4` object, depending on the version of the simulation
+        data.
+
+    Note that all remaining arguments (including keyword arguments)
+    are passed on to the `SimulationBase` constructors.
+
+    """
+    from .. import load
+
+    # Load the simulation catalog
+    simulations = load("RITsimulations")
+
+    # Check if simulation ID exists in the catalog
+    if location not in simulations:
+        raise ValueError(f"Simulation '{location}' not found in RIT simulations catalog.")
+
+    # Attach metadata to this object
+    series = simulations.dataframe.loc[location]
+    metadata = Metadata(dict(series))
+    files = {
+        "strain": {"link": metadata.extrap_strain_url},
+        "psi4": {"link": metadata.extrap_psi4_url},
+        "metadata": {"link": metadata.metadata_url},
+    }
+    version = "v4.0"
+
+    sim = RITSimulation_v4(
+        metadata=metadata,
+        series=series,
+        version=version,
+        files=files,
+        location=location,
+    )
+    sim.__file__ = str(sxs_directory("cache") / location)
+    return sim
+
+
+class RITSimulation_v4(SimulationBase):
+    """Simulation object for version 4 of the RIT data format
+
+    Note that users almost certainly never need to call this function;
+    see the `RITSimulation` function or `sxs.load` function instead.  See
+    also `SimulationBase` for the base class that this class inherits
+    from.
+    """
+
+    def __init__(self, metadata, series, version, files, location, *args, **kwargs):
+    # Note that we want just a subset of the constructor of SimulationBase here.
+    # Therefore, we don't use the super of SimulationsBase.
+    # This keeps the constructor clean and avoids setting positional arguments -
+    # sxs_id_stem, sxs_id, url, lev_numbers and lev_number to None.
+        self.metadata = metadata
+        self.series = series
+        self.version = version
+        self.location = location
+        self.files = files
+
+    def __repr__(self):
+        chi1 = self.series["relaxed_chi1"]
+        chi2 = self.series["relaxed_chi2"]
+        e = self.series.eccentricity
+        construction = f"""{type(self).__qualname__}("{self.location}")\n# """
+        construction += f"n_orbits={self.metadata.number_of_orbits:.3g} "
+        construction += f"q={(1/self.metadata.relaxed_mass_ratio_1_over_2):.3g} "
+        construction += f"""chi1=[{", ".join(f"{c:.3g}" for c in chi1)}] """
+        construction += f"""chi2=[{", ".join(f"{c:.3g}" for c in chi2)}] """
+        construction += f"e={e:.3g} simulation" if type(e) is float else f"{e=} simulation"
+        return construction
+
+    def load_waveform(self, location):
+
+        from ..waveforms import lvcnr
+
+        strain_url = self.metadata.extrap_strain_url
+        filename = Path(strain_url).name
+
+        path = sxs_directory("cache") / location / filename
+
+        if not path.exists():
+            download_file(strain_url, path)
+
+        w = lvcnr.load(path)
+        w.metadata = self.metadata
+
+        return w
+
+    distances = _not_implemented_function("distances")
+    closest_simulation = _not_implemented_function("closest_simulation")
+    load_horizons = _not_implemented_function("load_horizons")
+
+    @property
+    def strain(self):
+        if not hasattr(self, "_strain"):
+            self._strain = self.load_waveform(self.location)
+        return self._strain
+
+    Strain = strain
+    h = strain
+    H = strain
+
+    versions = _not_defined_property("versions")
+    lev = _not_defined_property("lev")
+    Lev = _not_defined_property("Lev")
+    metadata_path = _not_defined_property("metadata_path")
+    horizons = _not_defined_property("horizons")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,7 +1,7 @@
 import pytest
 import sxs
 from .conftest import skip_macOS_GH_actions_downloads
-
+import numpy as np
 
 @skip_macOS_GH_actions_downloads
 def test_catalog_file_sizes():
@@ -290,3 +290,15 @@ def test_issue_116():
             h4 = sxs.load(f"{temp_dir}/test", metadata={})
     assert h4.t.size == h3.t.size == h.t.size
     assert h4.t[0] == h3.t[0]
+
+
+@skip_macOS_GH_actions_downloads
+def test_sxs_load_rit_v4():
+    s = sxs.load("RIT:BBH:0084")
+    assert s.location == "RIT:BBH:0084"
+    assert s.version == "v4.0"
+    s.h
+    s.strain
+    s.H
+    s.Strain
+    assert np.allclose(s.h.max_norm_time(), 0.0)


### PR DESCRIPTION
Hi @duetosymmetry and @moble. I have added a class and a function for loading the RIT waveforms. Using this `sxs.load` can load and cache RIT waveforms. Please review the PR.

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--194.org.readthedocs.build/en/194/

<!-- readthedocs-preview sxs end -->