### PR TITLE
Add mul method to wmodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "scipy >=1.13",
   "numba >=0.55; implementation_name == 'cpython'",
   "quaternionic >=1.0.15",
-  "spherical >=1.0.15",
+  "spherical >=1.1.0",
   "h5py >=3",
   "inflection >=0.5.1",
   "requests >=2.24.0",

--- a/sxs/waveforms/format_handlers/rotating_paired_diff_multishuffle_bzip2.py
+++ b/sxs/waveforms/format_handlers/rotating_paired_diff_multishuffle_bzip2.py
@@ -567,6 +567,7 @@ def load(
         ell_min=ell_min,
         ell_max=ell_max,
         spin_weight=spin_weight,
+        multiplication_truncator=max
     )
 
     if convert_from_conjugate_pairs:

--- a/sxs/waveforms/format_handlers/rotating_paired_diff_multishuffle_bzip2.py
+++ b/sxs/waveforms/format_handlers/rotating_paired_diff_multishuffle_bzip2.py
@@ -567,7 +567,6 @@ def load(
         ell_min=ell_min,
         ell_max=ell_max,
         spin_weight=spin_weight,
-        multiplication_truncator=max
     )
 
     if convert_from_conjugate_pairs:

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -150,6 +150,33 @@ class WaveformModes(WaveformMixin, TimeSeries):
                 obj = TimeSeries(obj)
         return obj
 
+    def __mul__(self, other):
+        if isinstance(other, WaveformModes):
+            modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
+                self,
+                self.ell_min,
+                self.ell_max,
+                self.spin_weight,
+                other,
+                other.ell_min,
+                other.ell_max,
+                other.spin_weight,
+                ellmin_fg=None,
+                ellmax_fg=self.ell_max
+            )
+            return WaveformModes(
+                modes12_data,
+                time=self.time,
+                time_axis=0,
+                ell_min=modes12_ellmin,
+                ell_max=modes12_ellmax,
+                modes_axis=1,
+                spin_weight=modes12_spin,
+                frame=self.frame
+            )
+        else:
+            return super().__mul__(other)
+
     @property
     def modes_axis(self):
         """Axis of the array storing the various modes

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -154,7 +154,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
         """Addition method for two WaveformModes object.
 
         Raises TypeError if other is not a WaveformModes instance.
-        Raises ValueError if spin weights or data shapes are incompatible.
+        Raises ValueError if spin weights are incompatible.
         """
         if not isinstance(other, type(self)):
             raise TypeError(f"Cannot add WaveformModes class object with an object of type {type(other).__name__}.")
@@ -163,18 +163,33 @@ class WaveformModes(WaveformMixin, TimeSeries):
 
         if self.spin_weight != other.spin_weight:
             raise ValueError(f"Cannot add two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})")
-        if self.shape != other.shape:
-            raise ValueError(f"Cannot add two WaveformModes with different shape of the data array. ({self.shape=} and {other.shape=})")
 
-        result = self.data + other.data
+        mode_diff = self.n_modes - other.n_modes
 
-        return type(self)(result, **self._metadata)
+        data_self = np.pad(self.data, pad_width=((0, 0), (-mode_diff, 0))) if mode_diff < 0 else self.data
+
+        data_other = np.pad(other.data, pad_width=((0,0),(mode_diff,0))) if mode_diff > 0 else other.data
+
+        result = data_self + data_other
+        ell_min = min(self.ell_min, other.ell_min)
+
+        return type(self)(
+            result,
+            time=self.time,
+            time_axis=0,
+            ell_min=ell_min,
+            ell_max=self.ell_max,
+            modes_axis=1,
+            spin_weight=self.spin_weight,
+            frame=self.frame,
+            frame_type=self.frame_type,
+        )
 
     def __sub__(self, other):
         """Subtraction method for two WaveformModes object.
 
         Raises TypeError if other is not a WaveformModes instance.
-        Raises ValueError if spin weights or data shapes are incompatible.
+        Raises ValueError if spin weights are incompatible.
         """
         if not isinstance(other, type(self)):
             raise TypeError(f"Cannot subtract WaveformModes class object with an object of type {type(other).__name__}.")
@@ -183,12 +198,27 @@ class WaveformModes(WaveformMixin, TimeSeries):
 
         if self.spin_weight != other.spin_weight:
             raise ValueError(f"Cannot subtract two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})")
-        if self.shape != other.shape:
-            raise ValueError(f"Cannot subtract two WaveformModes with different shape of the data array. ({self.shape=} and {other.shape=})")
 
-        result = self.data - other.data
+        mode_diff = self.n_modes - other.n_modes
 
-        return type(self)(result, **self._metadata)
+        data_self = np.pad(self.data, pad_width=((0, 0), (-mode_diff, 0))) if mode_diff < 0 else self.data
+
+        data_other = np.pad(other.data, pad_width=((0,0),(mode_diff,0))) if mode_diff > 0 else other.data
+
+        result = data_self - data_other
+        ell_min = min(self.ell_min, other.ell_min)
+
+        return type(self)(
+            result,
+            time=self.time,
+            time_axis=0,
+            ell_min=ell_min,
+            ell_max=self.ell_max,
+            modes_axis=1,
+            spin_weight=self.spin_weight,
+            frame=self.frame,
+            frame_type=self.frame_type,
+        )
 
     def __mul__(self, other):
         """Multiplication method for two WaveformModes object.

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -151,19 +151,28 @@ class WaveformModes(WaveformMixin, TimeSeries):
         return obj
 
     def __mul__(self, other):
-        if isinstance(other, WaveformModes):
+        if isinstance(other, WaveformModes) and np.allclose(self.frame, other.frame):
+            if self.multiplication_truncator is not None:
+                new_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
+            else:
+                new_ell_max = max(
+                    truncator((self.ell_max, other.ell_max))
+                    for truncator in [
+                        self._metadata.get('multiplication_truncator', sum),
+                        other._metadata.get('multiplication_truncator', sum)
+                    ]
+                )
             modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
-                self,
-                self.ell_min,
-                self.ell_max,
-                self.spin_weight,
-                other,
-                other.ell_min,
-                other.ell_max,
-                other.spin_weight,
-                ellmin_fg=None,
-                ellmax_fg=self.ell_max
-            )
+            self,
+            self.ell_min,
+            self.ell_max,
+            self.spin_weight,
+            other,
+            other.ell_min,
+            other.ell_max,
+            other.spin_weight,
+            ellmax_fg=new_ell_max
+        )
             return WaveformModes(
                 modes12_data,
                 time=self.time,
@@ -199,6 +208,11 @@ class WaveformModes(WaveformMixin, TimeSeries):
     def ell_max(self):
         """Largest value of ℓ stored in the data"""
         return self._metadata["ell_max"]
+
+    @property
+    def multiplication_truncator(self):
+        """Multiplication truncator stored in the data"""
+        return self._metadata["multiplication_truncator"]
 
     @property
     def n_modes(self):

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -220,14 +220,16 @@ class WaveformModes(WaveformMixin, TimeSeries):
         return self + (-other)
 
     def __mul__(self, other):
-        """Multiplication method for two WaveformModes object.
+        """Multiplication method for two WaveformModes object; falls back to
+        the parent class if `other` is not a WaveformModes instance.
 
         First it checks if the two objects are compatible for multiplication
-        using the `_require_compatibility` method.
-        The output `ell_max` is determined by the `multiplication_truncator`
-        attribute. The left operand's truncator takes priority; if absent, the
-        right operand's truncator is used; if both are absent, it defaults to
-        the sum of the two `ell_max`.
+        using the `_require_compatibility` method and `modes_axis` of the
+        data.
+        The product `ell_max` and `multiplication_truncator` are determined by
+        applying each operand's `multiplication_truncator` to `(self.ell_max,
+        other.ell_max)`, and selecting the operand whose truncator yields the
+        larger result.
         ----
         Note that the `modes_axis` of self and other should be the last axis of
         the WaveformModes data as per spherical.multiply, otherwise a
@@ -236,12 +238,12 @@ class WaveformModes(WaveformMixin, TimeSeries):
         if not isinstance(other, type(self)):
             return super().__mul__(other)
 
+        self._require_compatibility(other)
+
         if self.modes_axis != self.ndim - 1:
             raise ValueError(
                 f"The modes_axis of self and other should be the last axis of the data (ndim-1={self.ndim - 1}), rather it is {self.modes_axis}."
             )
-
-        self._require_compatibility(other)
 
         self_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
         other_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -338,7 +338,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
         return self._metadata.get("multiplication_truncator", max)
 
     @multiplication_truncator.setter
-    def multiplication_truncation(self, truncator_prm):
+    def multiplication_truncator(self, truncator_prm):
         self._metadata["multiplication_truncator"] = truncator_prm
 
     @property

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -164,21 +164,24 @@ class WaveformModes(WaveformMixin, TimeSeries):
         if self.spin_weight != other.spin_weight:
             raise ValueError(f"Cannot add two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})")
 
-        mode_diff = self.n_modes - other.n_modes
-
-        data_self = np.pad(self.data, pad_width=((0, 0), (-mode_diff, 0))) if mode_diff < 0 else self.data
-
-        data_other = np.pad(other.data, pad_width=((0,0),(mode_diff,0))) if mode_diff > 0 else other.data
-
-        result = data_self + data_other
         ell_min = min(self.ell_min, other.ell_min)
+        ell_max = max(self.ell_max, other.ell_max)
+
+        result = np.zeros((self.time.size, spherical.Ysize(ell_min, ell_max)), dtype=self.dtype)
+
+        slice_1 = slice(spherical.Yindex(self.ell_min, -self.ell_min, ell_min), spherical.Yindex(self.ell_max + 1, -(self.ell_max + 1), ell_min),)
+
+        slice_2 = slice(spherical.Yindex(other.ell_min, -other.ell_min, ell_min), spherical.Yindex(other.ell_max + 1, -(other.ell_max + 1), ell_min),)
+
+        result[:, slice_1] += self.data
+        result[:, slice_2] += other.data
 
         return type(self)(
             result,
             time=self.time,
             time_axis=0,
             ell_min=ell_min,
-            ell_max=self.ell_max,
+            ell_max=ell_max,
             modes_axis=1,
             spin_weight=self.spin_weight,
             frame=self.frame,
@@ -199,21 +202,24 @@ class WaveformModes(WaveformMixin, TimeSeries):
         if self.spin_weight != other.spin_weight:
             raise ValueError(f"Cannot subtract two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})")
 
-        mode_diff = self.n_modes - other.n_modes
-
-        data_self = np.pad(self.data, pad_width=((0, 0), (-mode_diff, 0))) if mode_diff < 0 else self.data
-
-        data_other = np.pad(other.data, pad_width=((0,0),(mode_diff,0))) if mode_diff > 0 else other.data
-
-        result = data_self - data_other
         ell_min = min(self.ell_min, other.ell_min)
+        ell_max = max(self.ell_max, other.ell_max)
+
+        result = np.zeros((self.time.size, spherical.Ysize(ell_min, ell_max)), dtype=self.dtype)
+
+        slice_1 = slice(spherical.Yindex(self.ell_min, -self.ell_min, ell_min), spherical.Yindex(self.ell_max + 1, -(self.ell_max + 1), ell_min),)
+
+        slice_2 = slice(spherical.Yindex(other.ell_min, -other.ell_min, ell_min), spherical.Yindex(other.ell_max + 1, -(other.ell_max + 1), ell_min),)
+
+        result[:, slice_1] += self.data
+        result[:, slice_2] -= other.data
 
         return type(self)(
             result,
             time=self.time,
             time_axis=0,
             ell_min=ell_min,
-            ell_max=self.ell_max,
+            ell_max=ell_max,
             modes_axis=1,
             spin_weight=self.spin_weight,
             frame=self.frame,
@@ -252,7 +258,8 @@ class WaveformModes(WaveformMixin, TimeSeries):
         other.ell_max,
         other.spin_weight,
         ellmax_fg=new_ell_max
-    )
+        )
+
         ell_min = abs(modes12_spin)
         modes_data = modes12_data[:,spherical.Yindex(ell_min, - ell_min, modes12_ellmin) : ]
 
@@ -286,6 +293,8 @@ class WaveformModes(WaveformMixin, TimeSeries):
             raise ValueError(f"Both waveforms must have identical frame arrays.")
         if not np.array_equal(self.time, other.time):
             raise ValueError(f"Both waveforms must have identical time arrays.")
+        if not self.time_axis==other.time_axis:
+            raise ValueError(f"The time axis of the two waveforms must be same for algebraic operations.")
 
         return True
 

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -150,6 +150,46 @@ class WaveformModes(WaveformMixin, TimeSeries):
                 obj = TimeSeries(obj)
         return obj
 
+    def __add__(self, other):
+        """Addition method for two WaveformModes object.
+
+        Raises TypeError if other is not a WaveformModes instance.
+        Raises ValueError if spin weights or data shapes are incompatible.
+        """
+        if not isinstance(other, WaveformModes):
+            raise TypeError(f"Cannot add WaveformModes class object with an object of type {type(other).__name__}.")
+
+        self._is_compatible(other)
+
+        if self.spin_weight != other.spin_weight:
+            raise ValueError(f"Cannot add two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})")
+        if self.shape != other.shape:
+            raise ValueError(f"Cannot add two WaveformModes with different shape of the data array. ({self.shape=} and {other.shape=})")
+
+        result = self.data + other.data
+
+        return type(self)(result, **self._metadata)
+
+    def __sub__(self, other):
+        """Subtraction method for two WaveformModes object.
+
+        Raises TypeError if other is not a WaveformModes instance.
+        Raises ValueError if spin weights or data shapes are incompatible.
+        """
+        if not isinstance(other, WaveformModes):
+            raise TypeError(f"Cannot subtract WaveformModes class object with an object of type {type(other).__name__}.")
+
+        self._is_compatible(other)
+
+        if self.spin_weight != other.spin_weight:
+            raise ValueError(f"Cannot subtract two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})")
+        if self.shape != other.shape:
+            raise ValueError(f"Cannot subtract two WaveformModes with different shape of the data array. ({self.shape=} and {other.shape=})")
+
+        result = self.data - other.data
+
+        return type(self)(result, **self._metadata)
+
     def __mul__(self, other):
         """Multiplication method for two WaveformModes object.
 
@@ -160,13 +200,16 @@ class WaveformModes(WaveformMixin, TimeSeries):
         right operand's truncator is used; if both are absent, it defaults to
         the sum of the two `ell_max`.
         """
-        if isinstance(other, WaveformModes) and self._is_compatible(other):
+        if isinstance(other, WaveformModes):
+
+            self._is_compatible(other)
+
             if self.multiplication_truncator is not None:
                 new_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
             elif other.multiplication_truncator is not None:
                 new_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))
             else:
-                new_ell_max = sum(self.ell_max, other.ell_max)
+                new_ell_max = self.ell_max + other.ell_max
 
             modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
             self,

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -162,16 +162,24 @@ class WaveformModes(WaveformMixin, TimeSeries):
         self._is_compatible(other)
 
         if self.spin_weight != other.spin_weight:
-            raise ValueError(f"Cannot add two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})")
+            raise ValueError(
+                f"Cannot add two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})."
+            )
 
         ell_min = min(self.ell_min, other.ell_min)
         ell_max = max(self.ell_max, other.ell_max)
 
         result = np.zeros((self.time.size, spherical.Ysize(ell_min, ell_max)), dtype=self.dtype)
 
-        slice_1 = slice(spherical.Yindex(self.ell_min, -self.ell_min, ell_min), spherical.Yindex(self.ell_max + 1, -(self.ell_max + 1), ell_min),)
+        slice_1 = slice(
+            spherical.Yindex(self.ell_min, -self.ell_min, ell_min),
+            spherical.Yindex(self.ell_max + 1, -(self.ell_max + 1), ell_min),
+        )
 
-        slice_2 = slice(spherical.Yindex(other.ell_min, -other.ell_min, ell_min), spherical.Yindex(other.ell_max + 1, -(other.ell_max + 1), ell_min),)
+        slice_2 = slice(
+            spherical.Yindex(other.ell_min, -other.ell_min, ell_min),
+            spherical.Yindex(other.ell_max + 1, -(other.ell_max + 1), ell_min),
+        )
 
         result[:, slice_1] += self.data
         result[:, slice_2] += other.data
@@ -188,43 +196,21 @@ class WaveformModes(WaveformMixin, TimeSeries):
             frame_type=self.frame_type,
         )
 
+    def __neg__(self):
+        """Return a new WaveformModes object with negated data.
+
+        Applies negation to the underlying mode data while
+        preserving all metadata.
+        """
+        return type(self)(-self.data, **self._metadata)
+
     def __sub__(self, other):
         """Subtraction method for two WaveformModes object.
 
         Raises TypeError if other is not a WaveformModes instance.
         Raises ValueError if spin weights are incompatible.
         """
-        if not isinstance(other, type(self)):
-            raise TypeError(f"Cannot subtract WaveformModes class object with an object of type {type(other).__name__}.")
-
-        self._is_compatible(other)
-
-        if self.spin_weight != other.spin_weight:
-            raise ValueError(f"Cannot subtract two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})")
-
-        ell_min = min(self.ell_min, other.ell_min)
-        ell_max = max(self.ell_max, other.ell_max)
-
-        result = np.zeros((self.time.size, spherical.Ysize(ell_min, ell_max)), dtype=self.dtype)
-
-        slice_1 = slice(spherical.Yindex(self.ell_min, -self.ell_min, ell_min), spherical.Yindex(self.ell_max + 1, -(self.ell_max + 1), ell_min),)
-
-        slice_2 = slice(spherical.Yindex(other.ell_min, -other.ell_min, ell_min), spherical.Yindex(other.ell_max + 1, -(other.ell_max + 1), ell_min),)
-
-        result[:, slice_1] += self.data
-        result[:, slice_2] -= other.data
-
-        return type(self)(
-            result,
-            time=self.time,
-            time_axis=0,
-            ell_min=ell_min,
-            ell_max=ell_max,
-            modes_axis=1,
-            spin_weight=self.spin_weight,
-            frame=self.frame,
-            frame_type=self.frame_type,
-        )
+        return self + (-other)
 
     def __mul__(self, other):
         """Multiplication method for two WaveformModes object.
@@ -241,29 +227,29 @@ class WaveformModes(WaveformMixin, TimeSeries):
 
         self._is_compatible(other)
 
-        if self.multiplication_truncator is not None:
-            new_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
-        elif other.multiplication_truncator is not None:
-            new_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))
-        else:
-            new_ell_max = self.ell_max + other.ell_max
+        truncator = self.multiplication_truncator or other.multiplication_truncator or sum
+        new_ell_max = truncator((self.ell_max, other.ell_max))
 
         modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
-        self,
-        self.ell_min,
-        self.ell_max,
-        self.spin_weight,
-        other,
-        other.ell_min,
-        other.ell_max,
-        other.spin_weight,
-        ellmax_fg=new_ell_max
+            self,
+            self.ell_min,
+            self.ell_max,
+            self.spin_weight,
+            other,
+            other.ell_min,
+            other.ell_max,
+            other.spin_weight,
+            ellmax_fg=new_ell_max
         )
 
         ell_min = abs(modes12_spin)
+
+        if ell_min > modes12_ellmax:
+            raise ValueError(f"ell_min ({ell_min}) of the product self*other exceeds ell_max ({modes12_ellmax}), resulting in no valid modes.")
+
         modes_data = modes12_data[:,spherical.Yindex(ell_min, - ell_min, modes12_ellmin) : ]
 
-        return WaveformModes(
+        return type(self)(
             modes_data,
             time=self.time,
             time_axis=0,
@@ -273,7 +259,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
             spin_weight=modes12_spin,
             frame=self.frame,
             frame_type=self.frame_type,
-            multiplication_truncator=self.multiplication_truncator
+            multiplication_truncator=truncator
         )
 
     def __truediv__(self, other):
@@ -288,7 +274,9 @@ class WaveformModes(WaveformMixin, TimeSeries):
         """Helper function to check if two waveform modes are compatible for
         algebraic operations."""
         if self.frame_type!=other.frame_type:
-            raise ValueError(f"Both waveforms must have identical frame types; self has `{self.frame_type=}`, other has `{other.frame_type=}`.")
+            raise ValueError(
+                f"Both waveforms must have identical frame types; self has `{self.frame_type=}`, other has `{other.frame_type=}`."
+        )
         if not np.array_equal(self.frame, other.frame):
             raise ValueError(f"Both waveforms must have identical frame arrays.")
         if not np.array_equal(self.time, other.time):
@@ -324,7 +312,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
     @property
     def multiplication_truncator(self):
         """Multiplication truncator stored in the data"""
-        return self._metadata["multiplication_truncator"]
+        return self._metadata.get("multiplication_truncator", None)
 
     @property
     def n_modes(self):

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -151,17 +151,23 @@ class WaveformModes(WaveformMixin, TimeSeries):
         return obj
 
     def __mul__(self, other):
-        if isinstance(other, WaveformModes) and np.allclose(self.frame, other.frame):
+        """Multiplication method for two WaveformModes object.
+
+        First it checks if the two objects are compatible for multiplication
+        using the `_is_compatible` method.
+        The output `ell_max` is determined by the `multiplication_truncator`
+        attribute. The left operand's truncator takes priority; if absent, the
+        right operand's truncator is used; if both are absent, it defaults to
+        the sum of the two `ell_max`.
+        """
+        if isinstance(other, WaveformModes) and self._is_compatible(other):
             if self.multiplication_truncator is not None:
                 new_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
+            elif other.multiplication_truncator is not None:
+                new_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))
             else:
-                new_ell_max = max(
-                    truncator((self.ell_max, other.ell_max))
-                    for truncator in [
-                        self._metadata.get('multiplication_truncator', sum),
-                        other._metadata.get('multiplication_truncator', sum)
-                    ]
-                )
+                new_ell_max = sum(self.ell_max, other.ell_max)
+
             modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
             self,
             self.ell_min,
@@ -181,10 +187,24 @@ class WaveformModes(WaveformMixin, TimeSeries):
                 ell_max=modes12_ellmax,
                 modes_axis=1,
                 spin_weight=modes12_spin,
-                frame=self.frame
+                frame=self.frame,
+                frame_type=self.frame_type,
+                multiplication_truncator=max
             )
         else:
             return super().__mul__(other)
+
+    def _is_compatible(self,other):
+        """Helper function to check if two waveform modes are compatible for
+        algebraic operations."""
+        if self.frame_type!=other.frame_type:
+            raise ValueError(f"Both waveforms must have identical frame types; self has `{self.frame_type=}`, other has `{other.frame_type=}`.")
+        if not np.array_equal(self.frame, other.frame):
+            raise ValueError(f"Both waveforms must have identical frame arrays.")
+        if not np.array_equal(self.time, other.time):
+            raise ValueError(f"Both waveforms must have identical time arrays.")
+
+        return True
 
     @property
     def modes_axis(self):

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -1551,33 +1551,6 @@ class WaveformModes(WaveformMixin, TimeSeries):
 
         return h_without_memory
 
-    def transpose(self):
-        """Return a waveform modes object with transposed data.
-
-        The resulting object will have a transposed data array with time_axis
-        and modes_axis swapped.
-        """
-        return type(self)(
-            self.data.T,
-            time=self.time,
-            time_axis=self.modes_axis,
-            ell_min=self.ell_min,
-            ell_max=self.ell_max,
-            modes_axis=self.time_axis,
-            spin_weight=self.spin_weight,
-            frame=self.frame,
-            frame_type=self.frame_type,
-            multiplication_truncator=self.multiplication_truncator
-        )
-
-    @property
-    def T(self):
-        """Returns the transpose of this waveform modes object.
-
-        Equivalent to calling transpose(). See transpose() for details.
-        """
-        return self.transpose()
-
 class WaveformModesDict(MutableMapping, WaveformModes):
     """A dictionary-like class for storing waveform modes
 

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -155,19 +155,26 @@ class WaveformModes(WaveformMixin, TimeSeries):
 
         Raises TypeError if other is not a WaveformModes instance.
         Raises ValueError if spin weights are incompatible.
+        Raises ValueErrors if the two WaveformModes object aren't compatible for
+        algebraic oeprations.
         """
         if not isinstance(other, type(self)):
             raise TypeError(f"Cannot add WaveformModes class object with an object of type {type(other).__name__}.")
-
-        self._is_compatible(other)
 
         if self.spin_weight != other.spin_weight:
             raise ValueError(
                 f"Cannot add two WaveformModes with different spin weights ({self.spin_weight=} and {other.spin_weight=})."
             )
 
+        self._require_compatibility(other)
+
         ell_min = min(self.ell_min, other.ell_min)
         ell_max = max(self.ell_max, other.ell_max)
+
+        n_modes = spherical.Ysize(ell_min, ell_max)
+        shape = list(np.broadcast_shapes(self.shape, other.shape))
+        shape[self.modes_axis] = n_modes
+        result = np.zeros(shape, dtype=np.result_type(self, other))
 
         # Compute slices into `result` corresponding to `self` and `other`'s modes axes
         slice_1 = slice(
@@ -179,21 +186,13 @@ class WaveformModes(WaveformMixin, TimeSeries):
             spherical.Yindex(other.ell_max, other.ell_max, ell_min) + 1,
         )
 
-        if self.time_axis != other.time_axis:
-            other = other.T
-
-        n_modes = spherical.Ysize(ell_min, ell_max)
-        shape = list(np.broadcast_shapes(self.shape, other.shape))
-        shape[self.modes_axis] = n_modes
-        result = np.zeros(shape, dtype=np.result_type(self, other))
-
         idx1 = [slice(None)] * self.ndim
         idx1[self.modes_axis] = slice_1
         idx2 = [slice(None)] * other.ndim
         idx2[other.modes_axis] = slice_2
 
-        result[idx1] += self.data
-        result[idx2] += other.data
+        result[tuple(idx1)] += self.data
+        result[tuple(idx2)] += other.data
 
         metadata = self._metadata.copy()
         metadata.update(
@@ -224,64 +223,67 @@ class WaveformModes(WaveformMixin, TimeSeries):
         """Multiplication method for two WaveformModes object.
 
         First it checks if the two objects are compatible for multiplication
-        using the `_is_compatible` method.
+        using the `_require_compatibility` method.
         The output `ell_max` is determined by the `multiplication_truncator`
         attribute. The left operand's truncator takes priority; if absent, the
         right operand's truncator is used; if both are absent, it defaults to
         the sum of the two `ell_max`.
+        ----
+        Note that the `modes_axis` of self and other should be the last axis of
+        the WaveformModes data as per spherical.multiply, otherwise it raises a
+        ValueError.
         """
         if not isinstance(other, type(self)):
             return super().__mul__(other)
 
-        self._is_compatible(other)
+        if self.modes_axis != self.ndim - 1:
+            raise ValueError(
+                f"The modes_axis of self and other should be the last axis of the data (ndim-1={self.ndim - 1}), rather it is {self.modes_axis}."
+            )
 
-        time_axis = self.time_axis
+        self._require_compatibility(other)
 
         self_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
         other_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))
+
         if self_ell_max >= other_ell_max:
             truncator = self.multiplication_truncator
             new_ell_max = self_ell_max
         else:
-        	truncator = other.multiplication_truncator
-        	new_ell_max = other_ell_max
-        end
+            truncator = other.multiplication_truncator
+            new_ell_max = other_ell_max
 
-        modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
-            left_WM,
-            left_WM.ell_min,
-            left_WM.ell_max,
-            left_WM.spin_weight,
-            right_WM,
-            right_WM.ell_min,
-            right_WM.ell_max,
-            right_WM.spin_weight,
-            ellmax_fg=new_ell_max
-        )
-
+        modes12_spin = self.spin_weight + other.spin_weight
         ell_min = abs(modes12_spin)
 
-        if ell_min > modes12_ellmax:
-            raise ValueError(f"ell_min ({ell_min}) of the product self*other exceeds ell_max ({modes12_ellmax}), resulting in no valid modes.")
+        if ell_min > new_ell_max:
+            raise ValueError(f"ell_min ({ell_min}) of the product self*other exceeds ell_max ({new_ell_max}), resulting in no valid modes.")
+
+        modes12_data, modes12_ellmin, new_ell_max, modes12_spin = spherical.multiply(
+            self,
+            self.ell_min,
+            self.ell_max,
+            self.spin_weight,
+            other,
+            other.ell_min,
+            other.ell_max,
+            other.spin_weight,
+            ellmax_fg=new_ell_max
+        )
 
         start_idx = spherical.Yindex(ell_min, - ell_min, modes12_ellmin)
 
         modes_data = modes12_data[..., start_idx: ]
 
-        result = type(self)(
-                modes_data,
-                time=self.time,
-                time_axis=self.time_axis,
-                ell_min=ell_min,
-                ell_max=modes12_ellmax,
-                modes_axis=self.modes_axis,
-                spin_weight=modes12_spin,
-                frame=self.frame,
-                frame_type=self.frame_type,
-                multiplication_truncator=truncator
-            )
+        metadata = self._metadata.copy()
+        metadata.update(
+            ell_min=ell_min,
+            ell_max=new_ell_max,
+            spin_weight=modes12_spin,
+            multiplication_truncator=truncator
+        )
 
-        return result
+        return type(self)(modes_data, **metadata)
 
     def __truediv__(self, other):
         """Division of two WaveformModes object.
@@ -291,7 +293,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
         else:
             return super().__truediv__(other)
 
-    def _is_compatible(self,other):
+    def _require_compatibility(self,other):
         """Helper function to check if two waveform modes are compatible for
         algebraic operations."""
         if self.frame_type!=other.frame_type:
@@ -302,8 +304,10 @@ class WaveformModes(WaveformMixin, TimeSeries):
             raise ValueError(f"Both waveforms must have identical frame arrays.")
         if not np.array_equal(self.time, other.time):
             raise ValueError(f"Both waveforms must have identical time arrays.")
-
-        return True
+        if not self.time_axis==other.time_axis:
+            raise ValueError(f"Both waveforms must have identical time_axis.")
+        if not self.modes_axis==other.modes_axis:
+            raise ValueError(f"Both waveforms must have identical modes_axis.")
 
     @property
     def modes_axis(self):
@@ -332,6 +336,10 @@ class WaveformModes(WaveformMixin, TimeSeries):
     def multiplication_truncator(self):
         """Multiplication truncator stored in the data"""
         return self._metadata.get("multiplication_truncator", max)
+
+    @multiplication_truncator.setter
+    def multiplication_truncation(self, truncator_prm):
+        self._metadata["multiplication_truncator"] = truncator_prm
 
     @property
     def n_modes(self):

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -171,7 +171,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
         ell_min = min(self.ell_min, other.ell_min)
         ell_max = max(self.ell_max, other.ell_max)
 
-        n_modes = max(self.n_modes, other.n_modes)
+        n_modes = spherical.Ysize(ell_min, ell_max)
         shape = list(self.shape)
         shape[self.modes_axis] = n_modes
         result = np.zeros(shape, dtype=np.result_type(self, other))

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -171,7 +171,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
         ell_min = min(self.ell_min, other.ell_min)
         ell_max = max(self.ell_max, other.ell_max)
 
-        n_modes = spherical.Ysize(ell_min, ell_max)
+        n_modes = max(self.n_modes, other.n_modes)
         shape = list(self.shape)
         shape[self.modes_axis] = n_modes
         result = np.zeros(shape, dtype=np.result_type(self, other))
@@ -245,15 +245,15 @@ class WaveformModes(WaveformMixin, TimeSeries):
                 f"The modes_axis of self and other should be the last axis of the data (ndim-1={self.ndim - 1}), rather it is {self.modes_axis}."
             )
 
-        self_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
-        other_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))
+        self_new_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
+        other_new_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))
 
-        if self_ell_max >= other_ell_max:
+        if self_new_ell_max >= other_new_ell_max:
             truncator = self.multiplication_truncator
-            new_ell_max = self_ell_max
+            new_ell_max = self_new_ell_max
         else:
             truncator = other.multiplication_truncator
-            new_ell_max = other_ell_max
+            new_ell_max = other_new_ell_max
 
         modes12_spin = self.spin_weight + other.spin_weight
         ell_min = abs(modes12_spin)

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -223,11 +223,14 @@ class WaveformModes(WaveformMixin, TimeSeries):
         other.spin_weight,
         ellmax_fg=new_ell_max
     )
+        ell_min = abs(modes12_spin)
+        modes_data = modes12_data[:,spherical.Yindex(ell_min, - ell_min, modes12_ellmin) : ]
+
         return WaveformModes(
-            modes12_data,
+            modes_data,
             time=self.time,
             time_axis=0,
-            ell_min=modes12_ellmin,
+            ell_min=ell_min,
             ell_max=modes12_ellmax,
             modes_axis=1,
             spin_weight=modes12_spin,

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -169,27 +169,28 @@ class WaveformModes(WaveformMixin, TimeSeries):
         ell_min = min(self.ell_min, other.ell_min)
         ell_max = max(self.ell_max, other.ell_max)
 
+        # Compute slices into `result` corresponding to `self` and `other`'s modes axes
         slice_1 = slice(
             spherical.Yindex(self.ell_min, -self.ell_min, ell_min),
-            spherical.Yindex(self.ell_max + 1, -(self.ell_max + 1), ell_min),
+            spherical.Yindex(self.ell_max, self.ell_max, ell_min) + 1,
         )
-
         slice_2 = slice(
             spherical.Yindex(other.ell_min, -other.ell_min, ell_min),
-            spherical.Yindex(other.ell_max + 1, -(other.ell_max + 1), ell_min),
+            spherical.Yindex(other.ell_max, other.ell_max, ell_min) + 1,
         )
 
         if self.time_axis != other.time_axis:
             other = other.T
 
         n_modes = spherical.Ysize(ell_min, ell_max)
-        n_times = self.n_times
+        shape = list(np.broadcast_shapes(self.shape, other.shape))
+        shape[self.modes_axis] = n_modes
+        result = np.zeros(shape, dtype=np.result_type(self, other))
 
-        shape = (n_times, n_modes) if self.time_axis==0 else (n_modes, n_times)
-        result = np.zeros(shape, dtype=self.dtype)
-
-        idx1 = (slice(None), slice_1) if self.time_axis == 0 else (slice_1, slice(None))
-        idx2 = (slice(None), slice_2) if self.time_axis == 0 else (slice_2, slice(None))
+        idx1 = [slice(None)] * self.ndim
+        idx1[self.modes_axis] = slice_1
+        idx2 = [slice(None)] * other.ndim
+        idx2[other.modes_axis] = slice_2
 
         result[idx1] += self.data
         result[idx2] += other.data
@@ -201,7 +202,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
             spin_weight=self.spin_weight,
         )
 
-        return type(self)(result, metadata)
+        return type(self)(result, **metadata)
 
     def __neg__(self):
         """Return a new WaveformModes object with negated data.
@@ -236,11 +237,15 @@ class WaveformModes(WaveformMixin, TimeSeries):
 
         time_axis = self.time_axis
 
-        left_WM = self if self.time_axis == 0 else self.T
-        right_WM = other if other.time_axis == 0 else other.T
-
-        truncator = left_WM.multiplication_truncator or right_WM.multiplication_truncator or sum
-        new_ell_max = truncator((left_WM.ell_max, right_WM.ell_max))
+        self_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
+        other_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))
+        if self_ell_max >= other_ell_max:
+            truncator = self.multiplication_truncator
+            new_ell_max = self_ell_max
+        else:
+        	truncator = other.multiplication_truncator
+        	new_ell_max = other_ell_max
+        end
 
         modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
             left_WM,
@@ -261,23 +266,20 @@ class WaveformModes(WaveformMixin, TimeSeries):
 
         start_idx = spherical.Yindex(ell_min, - ell_min, modes12_ellmin)
 
-        modes_data = modes12_data[:, start_idx: ]
+        modes_data = modes12_data[..., start_idx: ]
 
         result = type(self)(
                 modes_data,
                 time=self.time,
-                time_axis=0,
+                time_axis=self.time_axis,
                 ell_min=ell_min,
                 ell_max=modes12_ellmax,
-                modes_axis=1,
+                modes_axis=self.modes_axis,
                 spin_weight=modes12_spin,
                 frame=self.frame,
                 frame_type=self.frame_type,
                 multiplication_truncator=truncator
             )
-
-        if time_axis != 0:
-            result = result.T
 
         return result
 
@@ -329,7 +331,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
     @property
     def multiplication_truncator(self):
         """Multiplication truncator stored in the data"""
-        return self._metadata.get("multiplication_truncator", None)
+        return self._metadata.get("multiplication_truncator", max)
 
     @property
     def n_modes(self):

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -156,7 +156,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
         Raises TypeError if other is not a WaveformModes instance.
         Raises ValueError if spin weights or data shapes are incompatible.
         """
-        if not isinstance(other, WaveformModes):
+        if not isinstance(other, type(self)):
             raise TypeError(f"Cannot add WaveformModes class object with an object of type {type(other).__name__}.")
 
         self._is_compatible(other)
@@ -176,7 +176,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
         Raises TypeError if other is not a WaveformModes instance.
         Raises ValueError if spin weights or data shapes are incompatible.
         """
-        if not isinstance(other, WaveformModes):
+        if not isinstance(other, type(self)):
             raise TypeError(f"Cannot subtract WaveformModes class object with an object of type {type(other).__name__}.")
 
         self._is_compatible(other)
@@ -200,42 +200,49 @@ class WaveformModes(WaveformMixin, TimeSeries):
         right operand's truncator is used; if both are absent, it defaults to
         the sum of the two `ell_max`.
         """
-        if isinstance(other, WaveformModes):
-
-            self._is_compatible(other)
-
-            if self.multiplication_truncator is not None:
-                new_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
-            elif other.multiplication_truncator is not None:
-                new_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))
-            else:
-                new_ell_max = self.ell_max + other.ell_max
-
-            modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
-            self,
-            self.ell_min,
-            self.ell_max,
-            self.spin_weight,
-            other,
-            other.ell_min,
-            other.ell_max,
-            other.spin_weight,
-            ellmax_fg=new_ell_max
-        )
-            return WaveformModes(
-                modes12_data,
-                time=self.time,
-                time_axis=0,
-                ell_min=modes12_ellmin,
-                ell_max=modes12_ellmax,
-                modes_axis=1,
-                spin_weight=modes12_spin,
-                frame=self.frame,
-                frame_type=self.frame_type,
-                multiplication_truncator=max
-            )
-        else:
+        if not isinstance(other, type(self)):
             return super().__mul__(other)
+
+        self._is_compatible(other)
+
+        if self.multiplication_truncator is not None:
+            new_ell_max = self.multiplication_truncator((self.ell_max, other.ell_max))
+        elif other.multiplication_truncator is not None:
+            new_ell_max = other.multiplication_truncator((self.ell_max, other.ell_max))
+        else:
+            new_ell_max = self.ell_max + other.ell_max
+
+        modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
+        self,
+        self.ell_min,
+        self.ell_max,
+        self.spin_weight,
+        other,
+        other.ell_min,
+        other.ell_max,
+        other.spin_weight,
+        ellmax_fg=new_ell_max
+    )
+        return WaveformModes(
+            modes12_data,
+            time=self.time,
+            time_axis=0,
+            ell_min=modes12_ellmin,
+            ell_max=modes12_ellmax,
+            modes_axis=1,
+            spin_weight=modes12_spin,
+            frame=self.frame,
+            frame_type=self.frame_type,
+            multiplication_truncator=self.multiplication_truncator
+        )
+
+    def __truediv__(self, other):
+        """Division of two WaveformModes object.
+        """
+        if isinstance(other, type(self)):
+            raise ValueError(f"Cannot divide one WaveformModes object by another")
+        else:
+            return super().__truediv__(other)
 
     def _is_compatible(self,other):
         """Helper function to check if two waveform modes are compatible for

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -172,7 +172,7 @@ class WaveformModes(WaveformMixin, TimeSeries):
         ell_max = max(self.ell_max, other.ell_max)
 
         n_modes = spherical.Ysize(ell_min, ell_max)
-        shape = list(np.broadcast_shapes(self.shape, other.shape))
+        shape = list(self.shape)
         shape[self.modes_axis] = n_modes
         result = np.zeros(shape, dtype=np.result_type(self, other))
 
@@ -230,8 +230,8 @@ class WaveformModes(WaveformMixin, TimeSeries):
         the sum of the two `ell_max`.
         ----
         Note that the `modes_axis` of self and other should be the last axis of
-        the WaveformModes data as per spherical.multiply, otherwise it raises a
-        ValueError.
+        the WaveformModes data as per spherical.multiply, otherwise a
+        ValueError is raised.
         """
         if not isinstance(other, type(self)):
             return super().__mul__(other)

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -169,8 +169,6 @@ class WaveformModes(WaveformMixin, TimeSeries):
         ell_min = min(self.ell_min, other.ell_min)
         ell_max = max(self.ell_max, other.ell_max)
 
-        result = np.zeros((self.time.size, spherical.Ysize(ell_min, ell_max)), dtype=self.dtype)
-
         slice_1 = slice(
             spherical.Yindex(self.ell_min, -self.ell_min, ell_min),
             spherical.Yindex(self.ell_max + 1, -(self.ell_max + 1), ell_min),
@@ -181,20 +179,22 @@ class WaveformModes(WaveformMixin, TimeSeries):
             spherical.Yindex(other.ell_max + 1, -(other.ell_max + 1), ell_min),
         )
 
-        result[:, slice_1] += self.data
-        result[:, slice_2] += other.data
+        if self.time_axis != other.time_axis:
+            other = other.T
 
-        return type(self)(
-            result,
-            time=self.time,
-            time_axis=0,
-            ell_min=ell_min,
-            ell_max=ell_max,
-            modes_axis=1,
-            spin_weight=self.spin_weight,
-            frame=self.frame,
-            frame_type=self.frame_type,
-        )
+        n_modes = spherical.Ysize(ell_min, ell_max)
+        n_times = self.n_times
+
+        shape = (n_times, n_modes) if self.time_axis==0 else (n_modes, n_times)
+        result = np.zeros(shape, dtype=self.dtype)
+
+        idx1 = (slice(None), slice_1) if self.time_axis == 0 else (slice_1, slice(None))
+        idx2 = (slice(None), slice_2) if self.time_axis == 0 else (slice_2, slice(None))
+
+        result[idx1] += self.data
+        result[idx2] += other.data
+
+        return type(self)(result, **self._metadata)
 
     def __neg__(self):
         """Return a new WaveformModes object with negated data.
@@ -227,18 +227,23 @@ class WaveformModes(WaveformMixin, TimeSeries):
 
         self._is_compatible(other)
 
-        truncator = self.multiplication_truncator or other.multiplication_truncator or sum
-        new_ell_max = truncator((self.ell_max, other.ell_max))
+        time_axis = self.time_axis
+
+        left_WM = self if self.time_axis == 0 else self.T
+        right_WM = other if other.time_axis == 0 else other.T
+
+        truncator = left_WM.multiplication_truncator or right_WM.multiplication_truncator or sum
+        new_ell_max = truncator((left_WM.ell_max, right_WM.ell_max))
 
         modes12_data, modes12_ellmin, modes12_ellmax, modes12_spin = spherical.multiply(
-            self,
-            self.ell_min,
-            self.ell_max,
-            self.spin_weight,
-            other,
-            other.ell_min,
-            other.ell_max,
-            other.spin_weight,
+            left_WM,
+            left_WM.ell_min,
+            left_WM.ell_max,
+            left_WM.spin_weight,
+            right_WM,
+            right_WM.ell_min,
+            right_WM.ell_max,
+            right_WM.spin_weight,
             ellmax_fg=new_ell_max
         )
 
@@ -247,20 +252,27 @@ class WaveformModes(WaveformMixin, TimeSeries):
         if ell_min > modes12_ellmax:
             raise ValueError(f"ell_min ({ell_min}) of the product self*other exceeds ell_max ({modes12_ellmax}), resulting in no valid modes.")
 
-        modes_data = modes12_data[:,spherical.Yindex(ell_min, - ell_min, modes12_ellmin) : ]
+        start_idx = spherical.Yindex(ell_min, - ell_min, modes12_ellmin)
 
-        return type(self)(
-            modes_data,
-            time=self.time,
-            time_axis=0,
-            ell_min=ell_min,
-            ell_max=modes12_ellmax,
-            modes_axis=1,
-            spin_weight=modes12_spin,
-            frame=self.frame,
-            frame_type=self.frame_type,
-            multiplication_truncator=truncator
-        )
+        modes_data = modes12_data[:, start_idx: ]
+
+        result = type(self)(
+                modes_data,
+                time=self.time,
+                time_axis=0,
+                ell_min=ell_min,
+                ell_max=modes12_ellmax,
+                modes_axis=1,
+                spin_weight=modes12_spin,
+                frame=self.frame,
+                frame_type=self.frame_type,
+                multiplication_truncator=truncator
+            )
+
+        if time_axis != 0:
+            result = result.T
+
+        return result
 
     def __truediv__(self, other):
         """Division of two WaveformModes object.
@@ -281,8 +293,6 @@ class WaveformModes(WaveformMixin, TimeSeries):
             raise ValueError(f"Both waveforms must have identical frame arrays.")
         if not np.array_equal(self.time, other.time):
             raise ValueError(f"Both waveforms must have identical time arrays.")
-        if not self.time_axis==other.time_axis:
-            raise ValueError(f"The time axis of the two waveforms must be same for algebraic operations.")
 
         return True
 
@@ -1523,8 +1533,34 @@ class WaveformModes(WaveformMixin, TimeSeries):
         h_without_memory = raw_remove_memory(self, integration_start_time=integration_start_time)
 
         return h_without_memory
-        
-        
+
+    def transpose(self):
+        """Return a waveform modes object with transposed data.
+
+        The resulting object will have a transposed data array with time_axis
+        and modes_axis swapped.
+        """
+        return type(self)(
+            self.data.T,
+            time=self.time,
+            time_axis=self.modes_axis,
+            ell_min=self.ell_min,
+            ell_max=self.ell_max,
+            modes_axis=self.time_axis,
+            spin_weight=self.spin_weight,
+            frame=self.frame,
+            frame_type=self.frame_type,
+            multiplication_truncator=self.multiplication_truncator
+        )
+
+    @property
+    def T(self):
+        """Returns the transpose of this waveform modes object.
+
+        Equivalent to calling transpose(). See transpose() for details.
+        """
+        return self.transpose()
+
 class WaveformModesDict(MutableMapping, WaveformModes):
     """A dictionary-like class for storing waveform modes
 

--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -194,7 +194,14 @@ class WaveformModes(WaveformMixin, TimeSeries):
         result[idx1] += self.data
         result[idx2] += other.data
 
-        return type(self)(result, **self._metadata)
+        metadata = self._metadata.copy()
+        metadata.update(
+            ell_min=ell_min,
+            ell_max=ell_max,
+            spin_weight=self.spin_weight,
+        )
+
+        return type(self)(result, metadata)
 
     def __neg__(self):
         """Return a new WaveformModes object with negated data.

--- a/tests/test_waveforms.py
+++ b/tests/test_waveforms.py
@@ -316,3 +316,44 @@ def test_rpdmb():
         assert np.array_equal(w2.t, w3.t)
         assert np.array_equal(w2.data, w3.data)
         assert np.array_equal(w2.frame, w3.frame)
+
+def test_type_and_spin_in_modes_addition():
+
+    t = np.linspace(0.,10.,50)
+    n_times = len(t)
+
+    l = 1
+    α_data = np.random.rand(n_times, 2*l+1)
+    α = sxs.WaveformModes(α_data, t, modes_axis=1, ell_min=l, ell_max=l,spin_weight=0)
+
+    ϕ_data = np.zeros_like(α_data)
+
+    with pytest.raises(TypeError):
+        α + ϕ_data
+
+    ϕ = sxs.WaveformModes(ϕ_data, t, modes_axis=1, ell_min=l, ell_max=l,spin_weight=1)
+
+    with pytest.raises(ValueError):
+        α + ϕ
+
+def test_mode_multiplication_with_identity():
+
+    t = np.linspace(0.,10.,50)
+    n_times = len(t)
+
+    l_1 = 1
+    s_1 = 1
+    α_data = np.random.rand(n_times, 2*l_1 + 1)
+    α = sxs.WaveformModes(α_data, t, modes_axis=1, ell_min=l_1, ell_max=l_1, spin_weight=s_1)
+
+    l_2 = 0
+    s_2 = 0
+    ϕ_data = np.full((n_times, 2*l_2+1), np.sqrt(4*np.pi), dtype=complex)
+    ϕ = sxs.WaveformModes(ϕ_data, t, modes_axis=1, ell_min=l_2, ell_max=l_2,spin_weight=s_2)
+
+    #Multiplication by identity
+    β = α * ϕ
+    assert β.spin_weight == s_1 + s_2
+    assert β.ell_min >= abs(s_1 + s_2)
+    assert β.ell_max >= max(l_1, l_2)
+    assert np.allclose(β, α)


### PR DESCRIPTION
Hi @moble, @duetosymmetry, and @keefemitman. I am adding the `__mul__` method to the waveform modes class. Using this we can implement multiplication between waveform modes of different array size. I am using the attributes of the first Wmodes object to define the `l_max` of product. Please suggest improvements for this.

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--195.org.readthedocs.build/en/195/

<!-- readthedocs-preview sxs end -->