### PR TITLE
Remove polyfill from extra_javascript (domain compromised)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,7 +63,6 @@ extra_css:
 
 extra_javascript:
   - javascript/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js
 
 markdown_extensions:


### PR DESCRIPTION
See e.g. explanation at
https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack

Alternatively, I think we should be able to use the cloudflare hosted version,
see https://cdnjs.cloudflare.com/polyfill/

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--196.org.readthedocs.build/en/196/

<!-- readthedocs-preview sxs end -->