### PR TITLE
Add RITSimulation_v5 to load waveforms from v5 of the catalog.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Astronomy"
 ]
 dependencies = [
-  "sxscatalog >=3.0.28",
+  "sxscatalog >=3.0.29",
   "numpy >=2.0, <3.0",
   "scipy >=1.13",
   "numba >=0.55; implementation_name == 'cpython'",

--- a/sxs/simulations/rit_simulation.py
+++ b/sxs/simulations/rit_simulation.py
@@ -70,22 +70,25 @@ def RITSimulation(location, *args, **kwargs):
 
     resolution_tags = metadata.get("resolution_tags", [metadata.resolution_tag])
 
-    if resolution_tag is not None and resolution_tag not in resolution_tags:
-        raise ValueError(
-                f"Resolution tag '{resolution_tag}' not found in simulation files for {rit_id}."
-            )
-
     # If res is given as part of `location` use it; otherwise, use the highest
     # available.
     if resolution_tag is None:
         resolution_tag = max(resolution_tags, key = lambda r: int(r[1:]))
 
+    if resolution_tag not in resolution_tags:
+        raise ValueError(
+                f"Resolution tag '{resolution_tag}' not found in simulation files for {rit_id}."
+            )
+
+
     location = f"{rit_id}/{resolution_tag}"
 
+    # This adds "files" key to the metadata for backwards compatibility with v4
+    # tag of RITSimulations.json.
     if "files" not in metadata:
         files = {
         f"{resolution_tag}:extrap_strain.h5 ": {"link": metadata.extrap_strain_url},
-        f"{resolution_tag}:extrap_psi4.h5": {"link": metadata.extrap_psi4_url},
+        f"{resolution_tag}:extrap_psi4.tar.gz": {"link": metadata.extrap_psi4_url},
         f"{resolution_tag}:metadata.txt": {"link": metadata.metadata_url},
     }
         metadata.update(files=files)

--- a/sxs/simulations/rit_simulation.py
+++ b/sxs/simulations/rit_simulation.py
@@ -35,7 +35,7 @@ def RITSimulation(location, *args, **kwargs):
     "RIT:eBBH:xxxx". It must exist, or no files will be found to load the data
     from.
 
-    The returned object will be a `RITSimulation_v4` object.
+    The returned object will be a `RITSimulation_v5` object.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def RITSimulation(location, *args, **kwargs):
     Returns
     -------
     simulation : SimulationBase
-        An `RITSimulation_v4` object.
+        An `RITSimulation_v5` object.
 
     Note that all remaining arguments (including keyword arguments)
     are passed on to the `SimulationBase` constructors.
@@ -69,36 +69,30 @@ def RITSimulation(location, *args, **kwargs):
     metadata = simulations[rit_id]
 
     resolution_tags = metadata.get("resolution_tags", [metadata.resolution_tag])
-
+    max_resolution_tag = max(resolution_tags)
     # If res is given as part of `location` use it; otherwise, use the highest
     # available.
     if resolution_tag is None:
-        resolution_tag = max(resolution_tags, key = lambda r: int(r[1:]))
+        resolution_tag = max_resolution_tag
 
     if resolution_tag not in resolution_tags:
         raise ValueError(
                 f"Resolution tag '{resolution_tag}' not found in simulation files for {rit_id}."
             )
 
-
     location = f"{rit_id}/{resolution_tag}"
 
-    # This adds "files" key to the metadata for backwards compatibility with v4
-    # tag of RITSimulations.json.
-    if "files" not in metadata:
-        files = {
-        f"{resolution_tag}:extrap_strain.h5 ": {"link": metadata.extrap_strain_url},
-        f"{resolution_tag}:extrap_psi4.tar.gz": {"link": metadata.extrap_psi4_url},
-        f"{resolution_tag}:metadata.txt": {"link": metadata.metadata_url},
-    }
-        metadata.update(files=files)
+    files = metadata.files
 
-    files = {k: v for k,v in metadata.files.items() if k.startswith(resolution_tag)}
+    # Keep the metadata around unless we're asking for a lower res_tag
+    if (resolution_tag != max_resolution_tag):
+        metadata = None
 
     # There aren't multiple versions of the same simulation.
     # Hence, we set version to be the version of the latest catalog.
     version = "v5.0"
     sim = RITSimulation_v5(
+        metadata,
         series,
         version,
         rit_id,
@@ -195,7 +189,7 @@ class RITSimulation_v5(RITSimulation_v4):
     also `RITSimulation_v4` for the base class that this class inherits
     from.
     """
-    def __init__(self, series, version, rit_id, files, location, resolution_tag, resolution_tags, *args, **kwargs):
+    def __init__(self, metadata, series, version, rit_id, files, location, resolution_tag, resolution_tags, *args, **kwargs):
         self.series = series
         self.version = version
         self.rit_id = rit_id
@@ -203,7 +197,7 @@ class RITSimulation_v5(RITSimulation_v4):
         self.files = files
         self.resolution_tag = resolution_tag
         self.resolution_tags = resolution_tags
-        self.metadata = self.load_metadata()
+        self.metadata = metadata or self.load_metadata()
 
     @property
     def metadata_path(self):
@@ -230,23 +224,38 @@ class RITSimulation_v5(RITSimulation_v4):
         return metadata
 
     @property
-    def strain(self):
-        if not hasattr(self, "_strain"):
-            from ..waveforms import lvcnr
+    def strain_path(self):
+        if (fn:=f"{self.resolution_tag}:extrap_strain.h5") in self.files:
+            return fn
+        raise ValueError(
+            f"Strain file not found in simulation files for {self.location}"
+        )
 
-            strain_url = self.files[f"{self.resolution_tag}:extrap_strain.h5"]["link"]
-            strain_path = urllib.parse.urlparse(strain_url).path
-            filename = PurePosixPath(strain_path).name
-            location = Path(sxs_path_to_system_path(self.location))
+    def load_waveform(self, file_name):
+        from ..waveforms import lvcnr
 
-            path = sxs_directory("cache") / location / filename
+        strain_url = self.files.get(file_name)["link"]
+        strain_path = urllib.parse.urlparse(strain_url).path
+        filename = PurePosixPath(strain_path).name
+        location = Path(sxs_path_to_system_path(self.location))
 
-            if not path.exists():
-                download_file(strain_url, path)
+        path = sxs_directory("cache") / location / filename
 
-            w = lvcnr.load(path)
-            w.metadata = self.metadata
+        if not path.exists():
+            download_file(strain_url, path)
 
-            self._strain = w
+        w = lvcnr.load(path)
+        w.metadata = self.metadata
+
+        self._strain = w
         return self._strain
 
+    @property
+    def strain(self):
+        if not hasattr(self, "_strain"):
+            self._strain = self.load_waveform(self.strain_path)
+        return self._strain
+
+    Strain = strain
+    h = strain
+    H = strain

--- a/sxs/simulations/rit_simulation.py
+++ b/sxs/simulations/rit_simulation.py
@@ -68,7 +68,7 @@ def RITSimulation(location, *args, **kwargs):
     series = simulations.dataframe.loc[rit_id]
     metadata = simulations[rit_id]
 
-    resolution_tags = metadata.resolution_tags if "resolution_tags" in metadata else [metadata.resolution_tag]
+    resolution_tags = metadata.get("resolution_tags", [metadata.resolution_tag])
 
     if resolution_tag is not None and resolution_tag not in resolution_tags:
         raise ValueError(
@@ -90,7 +90,7 @@ def RITSimulation(location, *args, **kwargs):
     }
         metadata.update(files=files)
 
-    files = {k: v for k,v in metadata.files.items() if k.startswith(f"{resolution_tag}")}
+    files = {k: v for k,v in metadata.files.items() if k.startswith(resolution_tag)}
 
     # There aren't multiple versions of the same simulation.
     # Hence, we set version to be the version of the latest catalog.

--- a/sxs/simulations/rit_simulation.py
+++ b/sxs/simulations/rit_simulation.py
@@ -3,7 +3,16 @@ from pathlib import PurePosixPath, Path
 from .simulation import SimulationBase
 from .. import Metadata
 from ..utilities import download_file, sxs_directory, sxs_path_to_system_path
+from ..utilities.sxs_identifiers import sep_regex
+import re
 
+rit_id_regex = r"(?P<rit_identifier>RIT:BBH:[0-9]+)"
+res_regex = r"(?P<res>n[0-9]+)"
+rit_id_res_regex = rit_id_regex + rf"(?:{sep_regex}{res_regex})?"
+
+def rit_id_and_resolution_tag(r):
+    m = re.search(rit_id_res_regex, r)
+    return m["rit_identifier"], m["res"]
 
 def _not_defined_property(name):
     @property
@@ -48,29 +57,56 @@ def RITSimulation(location, *args, **kwargs):
     # Load the simulation catalog
     simulations = load("RITsimulations")
 
+    # Extract the simulation ID and the resolution number
+    rit_id, resolution_tag = rit_id_and_resolution_tag(location)
+
     # Check if simulation ID exists in the catalog
-    if location not in simulations:
-        raise ValueError(f"Simulation '{location}' not found in RIT simulations catalog.")
+    if rit_id not in simulations:
+        raise ValueError(f"Simulation '{rit_id}' not found in RIT simulations catalog.")
 
     # Attach metadata to this object
-    series = simulations.dataframe.loc[location]
-    metadata = Metadata(dict(series))
-    files = {
-        "strain": {"link": metadata.extrap_strain_url},
-        "psi4": {"link": metadata.extrap_psi4_url},
-        "metadata": {"link": metadata.metadata_url},
-    }
-    version = "v4.0"
+    series = simulations.dataframe.loc[rit_id]
+    metadata = simulations[rit_id]
 
-    sim = RITSimulation_v4(
-        metadata,
+    resolution_tags = metadata.resolution_tags if "resolution_tags" in metadata else [metadata.resolution_tag]
+
+    if resolution_tag is not None and resolution_tag not in resolution_tags:
+        raise ValueError(
+                f"Resolution tag '{resolution_tag}' not found in simulation files for {rit_id}."
+            )
+
+    # If res is given as part of `location` use it; otherwise, use the highest
+    # available.
+    if resolution_tag is None:
+        resolution_tag = max(resolution_tags, key = lambda r: int(r[1:]))
+
+    location = f"{rit_id}/{resolution_tag}"
+
+    if "files" not in metadata:
+        files = {
+        f"{resolution_tag}:extrap_strain.h5 ": {"link": metadata.extrap_strain_url},
+        f"{resolution_tag}:extrap_psi4.h5": {"link": metadata.extrap_psi4_url},
+        f"{resolution_tag}:metadata.txt": {"link": metadata.metadata_url},
+    }
+        metadata.update(files=files)
+
+    files = {k: v for k,v in metadata.files.items() if k.startswith(f"{resolution_tag}")}
+
+    # There aren't multiple versions of the same simulation.
+    # Hence, we set version to be the version of the latest catalog.
+    version = "v5.0"
+    sim = RITSimulation_v5(
         series,
         version,
+        rit_id,
         files,
         location,
+        resolution_tag,
+        resolution_tags,
         *args, **kwargs
     )
-    sim.__file__ = str(sxs_directory("cache") / sxs_path_to_system_path(location))
+
+    sim.__file__ = str(sxs_directory("cache") / sxs_path_to_system_path(rit_id))
     return sim
 
 
@@ -147,3 +183,67 @@ class RITSimulation_v4(SimulationBase):
     metadata_path = _not_defined_property("metadata_path")
     horizons = _not_defined_property("horizons")
     Horizons = horizons
+
+class RITSimulation_v5(RITSimulation_v4):
+    """Simulation object for version 5 of the RIT data format
+
+    Note that users almost certainly never need to call this function;
+    see the `RITSimulation` function or `sxs.load` function instead. See
+    also `RITSimulation_v4` for the base class that this class inherits
+    from.
+    """
+    def __init__(self, series, version, rit_id, files, location, resolution_tag, resolution_tags, *args, **kwargs):
+        self.series = series
+        self.version = version
+        self.rit_id = rit_id
+        self.location = location
+        self.files = files
+        self.resolution_tag = resolution_tag
+        self.resolution_tags = resolution_tags
+        self.metadata = self.load_metadata()
+
+    @property
+    def metadata_path(self):
+        if (fn:=f"{self.resolution_tag}:metadata.txt") in self.files:
+            return fn
+        raise ValueError(
+            f"Metadata file not found in simulation files for {self.location}"
+        )
+
+    def load_metadata(self):
+
+        metadata_url = self.files[self.metadata_path]["link"]
+        metadata_file_path = urllib.parse.urlparse(metadata_url).path
+        metadata_filename = PurePosixPath(metadata_file_path).name
+
+        metadata_truepath = sxs_directory("cache") / Path(self.rit_id) / metadata_filename
+
+        if not metadata_truepath.exists():
+                download_file(metadata_url, metadata_truepath)
+
+        metadata = Metadata.from_txt_file(metadata_truepath, cache_json=False)
+        metadata.pop("metadata_path", None)
+
+        return metadata
+
+    @property
+    def strain(self):
+        if not hasattr(self, "_strain"):
+            from ..waveforms import lvcnr
+
+            strain_url = self.files[f"{self.resolution_tag}:extrap_strain.h5"]["link"]
+            strain_path = urllib.parse.urlparse(strain_url).path
+            filename = PurePosixPath(strain_path).name
+            location = Path(sxs_path_to_system_path(self.location))
+
+            path = sxs_directory("cache") / location / filename
+
+            if not path.exists():
+                download_file(strain_url, path)
+
+            w = lvcnr.load(path)
+            w.metadata = self.metadata
+
+            self._strain = w
+        return self._strain
+

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -293,10 +293,9 @@ def test_issue_116():
 
 
 @skip_macOS_GH_actions_downloads
-def test_sxs_load_rit_v4():
-    s = sxs.load("RIT:BBH:0084")
-    assert s.location == "RIT:BBH:0084"
-    assert s.version == "v4.0"
+def test_sxs_load_rit():
+    s = sxs.load("RIT:BBH:0084/n100")
+    assert s.rit_id == "RIT:BBH:0084"
     s.h
     s.strain
     s.H


### PR DESCRIPTION
Hi @moble & @duetosymmetry - I am adding this subclass `RITSimulation_v5` to load waveforms from the latest RIT catalog release. I needed some suggestions on the structure:

In the function `RITSimulation`, I am forcing the version to be `v5` so that it uses just the RITSimulation_v5 class. Here `v5` corresponds to the catalog version rather than version of the waveforms. I think a better structure would be to merge `RITSimulation_v4` and `RITSimulation_v5` class into a single class called `RITSimulationBase`. If there are multiple versions of the simulations in the future, then we can create a different version using base class. 

I agree it would a significant change. I should have thought of organizing this the first time. Let me know what would be appropriate, and any feedback on the code.

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--203.org.readthedocs.build/en/203/

<!-- readthedocs-preview sxs end -->