### PR TITLE
Adding eth and ethbar property to maintain the shape

### DIFF
--- a/sxs/waveforms/waveform_modes.py
+++ b/sxs/waveforms/waveform_modes.py
@@ -572,8 +572,61 @@ class WaveformModes(WaveformMixin, TimeSeries):
     from spherical.modes.derivatives import (
         Lsquared, Lz, Lplus, Lminus,
         Rsquared, Rz, Rplus, Rminus,
-        eth, ethbar
     )
+
+    @property
+    def eth(self):
+        """Spin-raising derivative operator defined by Newman-Penrose
+        conventions.
+
+        The operator ð was originally defined in
+        https://dx.doi.org/10.1063/1.1931221, but is more completely defined in
+        https://dx.doi.org/10.1063/1.4962723.
+
+        See Also
+        --------
+        ethbar : Conjugate of this operator
+
+        """
+        eth_self = self.Rminus()
+        ell_min = eth_self.ell_min
+        l_min_from_s = abs(eth_self.spin_weight)
+
+        if ell_min == l_min_from_s:
+            return eth_self
+        else:
+            result = eth_self.data[:, eth_self.index(l_min_from_s, -l_min_from_s):]
+            metadata = eth_self._metadata.copy()
+            metadata.update(ell_min=l_min_from_s)
+
+            return type(self)(result, **metadata)
+
+    @property
+    def ethbar(self):
+        """Spin-lowering conjugate-derivative operator defined by Newman-Penrose
+        conventions.
+
+        The operator ð̄  was originally defined in
+        https://dx.doi.org/10.1063/1.1931221, but is more completely defined in
+        https://dx.doi.org/10.1063/1.4962723.
+
+        See Also
+        --------
+        eth : Conjugate of this operator
+
+        """
+        ethbar_self = -self.Rplus()
+        ell_min = ethbar_self.ell_min
+        l_min_from_s = abs(ethbar_self.spin_weight)
+
+        if ell_min == l_min_from_s:
+            return ethbar_self
+        else:
+            result = ethbar_self.data[:, ethbar_self.index(l_min_from_s, -l_min_from_s):]
+            metadata = ethbar_self._metadata.copy()
+            metadata.update(ell_min=l_min_from_s)
+
+            return type(self)(result, **metadata)
 
     @property
     def eth_GHP(self):


### PR DESCRIPTION
Hi @moble, @duetosymmetry, and @keefemitman 

I added the method `eth` and `ethbar` to `WaveformModes` object so that it adjusts the shape of the resulting operation to start from `ell_min` = `abs(eth_self.spin_weight)`. The spherical package was setting the shape of the result to be `metadata['ell_min'] = min(abs(self.spin_weight+1), self.ell_min)` (for eth & analogously for ethbar).

I encountered this issue of shape while using the `remove_memory` method of WModes. The function internally calls these operators, and it adds `l=0` and `l=1` modes (which are zero) to the data. I think it is better to not change the shape of the data after removing memory. Let me know if you have any suggestions or feedback on these changes.

<!-- readthedocs-preview sxs start -->
----
📚 Documentation preview 📚: https://sxs--207.org.readthedocs.build/en/207/

<!-- readthedocs-preview sxs end -->